### PR TITLE
fix/prevent-camera-jump-when-moving-elements

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 17,
+  "patchVersion": 18,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/scripts/components/Interactions/HotspotNavButton.js
+++ b/scripts/components/Interactions/HotspotNavButton.js
@@ -26,19 +26,20 @@ export default class HotspotNavButton extends React.Component {
     })
   }
 
-  toggleDrag = (e) => {
-    const dragBool = !this.state.canDrag
+  toggleDrag = () => {
+    const canDrag = this.state.canDrag
     this.setState({
-      canDrag: dragBool
+      canDrag: !canDrag
     })
-    if (!this.props.staticScene){
+
+    if (!this.props.staticScene) {
       //If we cant drag anymore, we start the rendering of the threesixty scene,
       // we also set the camera position that is stored wen we start the hotspot scaling
-      if(!this.state.canDrag) {
+      if (canDrag) { 
         this.context.threeSixty.startRendering()
         this.context.threeSixty.setCameraPosition(this.state.camPosYaw, this.state.camPosPitch)
-      } else {
 
+      } else {
         //We store the current position, because we are technically still dragging the background around here
         this.setState({
           camPosYaw : this.context.threeSixty.getCurrentPosition().yaw,

--- a/scripts/components/Interactions/NavigationButton.js
+++ b/scripts/components/Interactions/NavigationButton.js
@@ -155,10 +155,6 @@ export default class NavigationButton extends React.Component {
    * @param {FocusEvent} event 
    */
   onFocus(event) {
-    // By preventing default,
-    // ThreeSixty's focus listener will not trigger camera movement
-    event.preventDefault();
-
     // Already focused
     if (this.state.isFocused) {
       return;

--- a/scripts/components/Interactions/NavigationButton.js
+++ b/scripts/components/Interactions/NavigationButton.js
@@ -151,7 +151,14 @@ export default class NavigationButton extends React.Component {
     }
   }
 
-  onFocus() {
+  /**
+   * @param {FocusEvent} event 
+   */
+  onFocus(event) {
+    // By preventing default,
+    // ThreeSixty's focus listener will not trigger camera movement
+    event.preventDefault();
+
     // Already focused
     if (this.state.isFocused) {
       return;
@@ -160,17 +167,20 @@ export default class NavigationButton extends React.Component {
     this.setState({
       isFocused: true,
     });
+
     if (this.props.onFocusedInteraction) {
       this.props.onFocusedInteraction();
     }
-
   }
 
-  onBlur(e) {
+  /**
+   * @param {FocusEvent} event 
+   */
+  onBlur(event) {
     const navButtonWrapper = this.navButtonWrapper
       && this.navButtonWrapper.current;
 
-    if (navButtonWrapper && navButtonWrapper.contains(e.relatedTarget) && (!this.expandButton || e.relatedTarget !== this.expandButton.current)) {
+    if (navButtonWrapper && navButtonWrapper.contains(event.relatedTarget) && (!this.expandButton || event.relatedTarget !== this.expandButton.current)) {
       // Clicked target is child of button wrapper and not the expandButton, don't blur
       this.navButtonWrapper.current.focus({
         preventScroll: true
@@ -178,14 +188,12 @@ export default class NavigationButton extends React.Component {
       return;
     }
 
-
     this.setState({
       isFocused: false,
     });
     if (this.props.onBlur) {
       this.props.onBlur();
     }
-
   }
 
   componentDidMount() {

--- a/scripts/components/Interactions/NavigationButton.js
+++ b/scripts/components/Interactions/NavigationButton.js
@@ -300,7 +300,9 @@ export default class NavigationButton extends React.Component {
       && this.navButtonWrapper
       && this.navButtonWrapper.current;
     if (isFocusable) {
-      this.navButtonWrapper.current.focus({preventScroll: true});
+      this.navButtonWrapper.current.focus({
+        preventScroll: true
+      });
     }
   }
 

--- a/scripts/components/Interactions/NavigationButton.js
+++ b/scripts/components/Interactions/NavigationButton.js
@@ -182,9 +182,7 @@ export default class NavigationButton extends React.Component {
 
     if (navButtonWrapper && navButtonWrapper.contains(event.relatedTarget) && (!this.expandButton || event.relatedTarget !== this.expandButton.current)) {
       // Clicked target is child of button wrapper and not the expandButton, don't blur
-      this.navButtonWrapper.current.focus({
-        preventScroll: true
-      });
+      this.setFocus();
       return;
     }
 
@@ -205,9 +203,7 @@ export default class NavigationButton extends React.Component {
     this.addFocusListener();
     if (this.state.isFocused) {
       setTimeout(() => {
-        this.navButtonWrapper.current.focus({
-          preventScroll: true
-        });
+        this.setFocus();
       }, 0);
     }
   }
@@ -218,16 +214,13 @@ export default class NavigationButton extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.type && this.props.type === this.props.nextFocus && prevProps.nextFocus !== this.props.nextFocus) {
       this.skipFocus = true; // Prevent moving camera on next focus (makes for a better UX when using the mouse)
-      this.navButtonWrapper.current && this.navButtonWrapper.current.focus({
-        preventScroll: true
-      });
+      this.navButtonWrapper.current && this.setFocus();
     }
 
     if (this.props.isFocused && !prevProps.isFocused) {
       setTimeout(() => { // Note: Don't think the timeout is needed after rendering was fixed
-        this.navButtonWrapper.current && this.navButtonWrapper.current.focus({
-          preventScroll: true
-        });
+        this.context.threeSixty.preventCameraMovement = true;
+        this.navButtonWrapper.current && this.setFocus(true);
       }, 0);
     }
 
@@ -303,23 +296,22 @@ export default class NavigationButton extends React.Component {
     }
   }
 
-  setFocus() {
+  setFocus(preventCameraMovement = false) {
+    if(preventCameraMovement) {
+      this.context.threeSixty.setPreventCameraMovement(true);
+    }
     const isFocusable = this.context.extras.isEditor
       && this.navButtonWrapper
       && this.navButtonWrapper.current;
     if (isFocusable) {
-      this.navButtonWrapper.current.focus({
-        preventScroll: true
-      });
+      this.navButtonWrapper.current.focus({preventScroll: true});
     }
   }
 
   handleFocus = (e) => {
     if (this.context.extras.isEditor) {
       if (this.navButtonWrapper && this.navButtonWrapper.current && this.navButtonWrapper === e.target) {
-        this.navButtonWrapper.current.focus({
-          preventScroll: true
-        });
+        this.setFocus();
       }
       return;
     }

--- a/scripts/components/Interactions/NavigationButton.js
+++ b/scripts/components/Interactions/NavigationButton.js
@@ -210,13 +210,13 @@ export default class NavigationButton extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.type && this.props.type === this.props.nextFocus && prevProps.nextFocus !== this.props.nextFocus) {
       this.skipFocus = true; // Prevent moving camera on next focus (makes for a better UX when using the mouse)
-      this.navButtonWrapper.current && this.setFocus();
+      this.setFocus();
     }
 
     if (this.props.isFocused && !prevProps.isFocused) {
       setTimeout(() => { // Note: Don't think the timeout is needed after rendering was fixed
         this.context.threeSixty.preventCameraMovement = true;
-        this.navButtonWrapper.current && this.setFocus(true);
+        this.setFocus(true);
       }, 0);
     }
 


### PR DESCRIPTION
Prevent focus event default to stop camera from moving when user lets go of mouse