### PR TITLE
Add interaction id to three elements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ declare type Interaction = {
     showHotspotOnHover: boolean;
     showLabel: string;
   }
-  id? : string;
+  id: string;
 };
 
 declare type Action = {

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -364,6 +364,8 @@ export default class ThreeSixtyScene extends React.Component {
     }
 
     const onMount = (/** @type {HTMLElement} */ element) => { 
+      element.dataset.interactionId = interaction.id;
+
       this.props.threeSixty.add(
         element,
         ThreeSixtyScene.getPositionFromString(interaction.interactionpos),


### PR DESCRIPTION
We use this id for searching through three elements, instead of relying on indeces. The element's index is changed if we switch between 2d and 3d rendering, as it's deleted and re-added at the bottom of the list. Using a uuid instead is safer and more future-proof.