### PR TITLE
fix/prevent-camera-movement-in-three-sixty-scenes

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 20,
+  "patchVersion": 21,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/scripts/components/Interactions/NavigationButton.js
+++ b/scripts/components/Interactions/NavigationButton.js
@@ -293,7 +293,7 @@ export default class NavigationButton extends React.Component {
   }
 
   setFocus(preventCameraMovement = false) {
-    if(preventCameraMovement) {
+    if (preventCameraMovement && !this.props.staticScene) {
       this.context.threeSixty.setPreventCameraMovement(true);
     }
     const isFocusable = this.context.extras.isEditor


### PR DESCRIPTION
Previously got an error when trying to call `threeSixty` in static scenes where there's no instance of `ThreeSixty`.