### PR TITLE
Remove pointer lock timeout check

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 27,
+  "patchVersion": 28,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -77,17 +77,12 @@ export default class ThreeSixtyScene extends React.Component {
       return;
     }
 
-    // Already queued
-    if (this.pointerLockTimeout) {
-      return;
-    }
-
     this.setState({
       willPointerLock: true,
       pointerLockElement: element,
     });
 
-    this.pointerLockTimeout = window.setTimeout(() => {
+    window.setTimeout(() => {
       this.setState({
         hasPointerLock: true,
       });
@@ -110,7 +105,7 @@ export default class ThreeSixtyScene extends React.Component {
    * @private
    * 
    * Called when the scene is moved, caused by a drag event.
-   * @param  {H5P.Event} e
+   * @param {any} e
    */
   handleSceneMoveStart = (e) => {
     if (!this.context.extras.isEditor || e.data.isCamera) {


### PR DESCRIPTION
This null check would previously (pre 27f473d2dd0cc4720bace4c47e46e6502270add2) never be true, therefore it's obsolete. It prevented the `dragging` class from being added to dragged elements.