### PR TITLE
Play scene audio after video

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 54,
+  "patchVersion": 55,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/scripts/components/Main.js
+++ b/scripts/components/Main.js
@@ -491,6 +491,13 @@ export default class Main extends React.Component {
         showingPassword: false,
         nextFocus: null
       });
+
+      // Save the last scene player if any
+      if (this.state.audioIsPlaying && (isSceneAudio(this.state.audioIsPlaying) || isPlaylistAudio(this.state.audioIsPlaying)) ) {
+        this.setState({
+          sceneAudioWasPlaying: this.state.audioIsPlaying
+        });
+      }
     }
   }
 
@@ -500,6 +507,12 @@ export default class Main extends React.Component {
       currentInteraction: null,
       nextFocus: 'interaction-' + prevState.currentInteraction
     }));
+
+    // Play scene audio again if it was played before this interaction
+    if (!this.props.audioIsPlaying && this.state.sceneAudioWasPlaying) {
+      const lastplayer = this.sceneAudioPlayers[this.state.sceneAudioWasPlaying];
+      fadeAudioInAndOut(null, lastplayer, false);
+    }
   }
 
   hidePasswordDialog() {


### PR DESCRIPTION
If scene audio have been played before video interaction, it will now play the scene audio again when the interaction window is closed.