### PR TITLE
Make locked "go to scene" nav button black

### DIFF
--- a/scripts/components/Interactions/NavigationButton.scss
+++ b/scripts/components/Interactions/NavigationButton.scss
@@ -59,7 +59,7 @@ $labelWidth: 9em;
   }
 }
 
-.h5p-interaction-button {
+.h5p-interaction-button:not(.nav-button-wrapper--gotoscene) {
   .nav-button {
     background-color: $interactionBg;
 


### PR DESCRIPTION
To make it easier to see the difference between a locked activity and a locked "go to scene".