### PR TITLE
insert hints as restricted html

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 58,
+  "patchVersion": 59,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/scripts/components/Dialog/PasswordContent.js
+++ b/scripts/components/Dialog/PasswordContent.js
@@ -117,9 +117,10 @@ export default class PasswordContent extends React.Component {
               />
             </div>
             {this.props.hint && (
-              <span className={"h5p-field-text"}>
-                {`${this.context.l10n.hint}: ${this.props.hint}`}
-              </span>
+              <div className={"h5p-field-text"}>
+                {this.context.l10n.hint}:
+                <div dangerouslySetInnerHTML={{ __html: this.props.hint }} />
+              </div>
             )}
           </label>
           <button className={"h5p-password-btn"} onClick={this.handleOnClick}>

--- a/scripts/components/Dialog/PasswordContent.js
+++ b/scripts/components/Dialog/PasswordContent.js
@@ -118,7 +118,7 @@ export default class PasswordContent extends React.Component {
             </div>
             {this.props.hint && (
               <div className={"h5p-field-text"}>
-                {`${this.context.l10n.hint}: `}
+                <span className="h5p-password-hint-label">{`${this.context.l10n.hint}: `}</span>
                 <div className="h5p-password-hint" dangerouslySetInnerHTML={{ __html: this.props.hint }} />
               </div>
             )}

--- a/scripts/components/Dialog/PasswordContent.js
+++ b/scripts/components/Dialog/PasswordContent.js
@@ -118,8 +118,8 @@ export default class PasswordContent extends React.Component {
             </div>
             {this.props.hint && (
               <div className={"h5p-field-text"}>
-                {this.context.l10n.hint}:
-                <div dangerouslySetInnerHTML={{ __html: this.props.hint }} />
+                {`${this.context.l10n.hint}: `}
+                <div className="h5p-password-hint" dangerouslySetInnerHTML={{ __html: this.props.hint }} />
               </div>
             )}
           </label>

--- a/scripts/components/Dialog/PasswordContent.scss
+++ b/scripts/components/Dialog/PasswordContent.scss
@@ -110,6 +110,10 @@
     max-width: 70%;
     margin: 0.5em auto;
 
+    .h5p-password-hint-label {
+      font-weight: 600;
+    }
+
     .h5p-password-hint {
       display: inline;
 

--- a/scripts/components/Dialog/PasswordContent.scss
+++ b/scripts/components/Dialog/PasswordContent.scss
@@ -109,6 +109,17 @@
     line-height: 1em;
     max-width: 70%;
     margin: 0.5em auto;
+
+    .h5p-password-hint {
+      display: inline;
+
+      /**
+       * The div produced by the WYSIWYG editor
+       */
+      > div {
+        display: inline;
+      }
+    }
   }
 
   .h5p-field-input {

--- a/semantics.json
+++ b/semantics.json
@@ -244,7 +244,13 @@
                         "type": "text",
                         "label": "A hint for the interaction code",
                         "description": "An optional hint for the code, can be left empty if wanted",
-                        "optional": true
+                        "optional": true,
+                        "widget": "html",
+                        "tags": [
+                          "br",
+                          "strong",
+                          "em"
+                        ]
                       }
                     ]
                   },


### PR DESCRIPTION
Some characters where HTML escaped (e.g. `<` -> `&lt;`). We now insert the hint text as HTML to avoid this, and use a WYSIWYG editor to prevent editors from creating invalid HTML.