### PR TITLE
fix backwards compatibility

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 60,
+  "patchVersion": 61,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 59,
+  "patchVersion": 60,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 61,
+  "patchVersion": 62,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -24,6 +24,7 @@ H5P.ThreeImage = (function () {
     H5P.EventDispatcher.call(self);
 
     params.threeImage.scenes = Wrapper.addUniqueIdsToInteractions(params.threeImage.scenes);
+    params.threeImage.scenes = Wrapper.addMissingLabelSettings(params.threeImage.scenes);
     
     let wrapper;
     this.behavior = {
@@ -239,16 +240,34 @@ H5P.ThreeImage = (function () {
   * @returns {Array<SceneParams>}
   */
   Wrapper.addUniqueIdsToInteractions = scenes =>
-   scenes.map(scene => scene.interactions 
-     ? ({
-         ...scene,
-         interactions: scene.interactions.map(
-           interaction => ({...interaction, id: H5P.createUUID()}),
-         ),
-       }) 
-     : scene
-   );
+    scenes?.map(scene => scene.interactions 
+      ? ({
+          ...scene,
+          interactions: scene.interactions?.map(
+            interaction => ({...interaction, id: H5P.createUUID()}),
+          ),
+        }) 
+      : scene
+    );
  
+  /**
+   * Older interactions are missing label settings.
+   * This adds an empty `label` to avoid adding null checks everywhere.
+   * TODO: Add this to upgrades.json
+   * 
+   * @param {Array<SceneParams>} scenes 
+   * @returns {Array<SceneParams>}
+   */
+  Wrapper.addMissingLabelSettings = scenes =>
+      scenes?.map(scene => scene.interactions
+        ? ({
+          ...scene,
+          interactions: scene.interactions?.map(
+            interaction => ({...interaction, label: interaction.label ?? {}})
+          ),
+        })
+        : scene
+      );
 
   return Wrapper;
 })();

--- a/scripts/components/Scene/SceneTypes/StaticScene.js
+++ b/scripts/components/Scene/SceneTypes/StaticScene.js
@@ -423,7 +423,7 @@ export default class StaticScene extends React.Component {
               const key = interaction.id || `interaction-${this.props.sceneId}${index}`
 
               return (
-                interaction.label.showAsOpenSceneContent ?
+                interaction?.label.showAsOpenSceneContent ?
                 <OpenContent
                   key={key}
                   staticScene={true}

--- a/scripts/components/Scene/SceneTypes/StaticScene.js
+++ b/scripts/components/Scene/SceneTypes/StaticScene.js
@@ -421,9 +421,9 @@ export default class StaticScene extends React.Component {
               }
 
               const key = interaction.id || `interaction-${this.props.sceneId}${index}`
-              
+
               return (
-                interaction.label?.showAsOpenSceneContent ?
+                interaction.label.showAsOpenSceneContent ?
                 <OpenContent
                   key={key}
                   staticScene={true}

--- a/scripts/components/Scene/SceneTypes/StaticScene.js
+++ b/scripts/components/Scene/SceneTypes/StaticScene.js
@@ -421,9 +421,9 @@ export default class StaticScene extends React.Component {
               }
 
               const key = interaction.id || `interaction-${this.props.sceneId}${index}`
-
+              
               return (
-                interaction?.label.showAsOpenSceneContent ?
+                interaction.label?.showAsOpenSceneContent ?
                 <OpenContent
                   key={key}
                   staticScene={true}

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -384,7 +384,7 @@ export default class ThreeSixtyScene extends React.Component {
     
     const is3d = renderIn3d(interaction);
     const component = (
-      interaction?.label.showAsOpenSceneContent ?
+      interaction.label?.showAsOpenSceneContent ?
         <OpenContent
           key={key}
           mouseDownHandler={null}

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -383,6 +383,7 @@ export default class ThreeSixtyScene extends React.Component {
     const key = interaction.id || `interaction-${this.props.sceneId}${index}`
     
     const is3d = renderIn3d(interaction);
+
     const component = (
       interaction.label?.showAsOpenSceneContent ?
         <OpenContent

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -384,7 +384,7 @@ export default class ThreeSixtyScene extends React.Component {
     
     const is3d = renderIn3d(interaction);
     const component = (
-      interaction.label.showAsOpenSceneContent ?
+      interaction?.label.showAsOpenSceneContent ?
         <OpenContent
           key={key}
           mouseDownHandler={null}

--- a/upgrades.js
+++ b/upgrades.js
@@ -18,15 +18,15 @@ H5PUpgrades['H5P.ThreeImage'] = (function () {
         console.log("UPDATING VIRTUAL TOUR TO VERSION 0.4.\nParameters:");
         console.log(parameters);
         
-        if (parameters && parameters.behaviour) {
-          parameters.behaviour.label = {
+        if (parameters && parameters.context.behaviour) {
+          parameters.context.behaviour.label = {
             showLabel: false,
             labelPosition: 'right'
           };
         }
 
-        if (parameters && parameters.scenes) {
-          for (const scene of parameters.scenes) {
+        if (parameters && parameters.context.scenes) {
+          for (const scene of parameters.context.scenes) {
             if (scene.interactions) {
               for (const interaction of interactions) {
                 if (!interaction.label) {

--- a/upgrades.js
+++ b/upgrades.js
@@ -24,6 +24,22 @@ H5PUpgrades['H5P.ThreeImage'] = (function () {
             labelPosition: 'right'
           };
         }
+
+        if (parameters && parameters.scenes) {
+          for (const scene of parameters.scenes) {
+            if (scene.interactions) {
+              for (const interaction of interactions) {
+                if (!interaction.label) {
+                  interaction.label = {
+                    labelPosition: 'inherit',
+                    showLabel: 'inherit',
+                  }
+                }
+              }
+            }
+          }
+        }
+
         finished(null, parameters);
       }
     }

--- a/upgrades.js
+++ b/upgrades.js
@@ -15,9 +15,6 @@ H5PUpgrades['H5P.ThreeImage'] = (function () {
         finished(null, parameters);
       },
       4: function (parameters, finished) {
-        console.log("UPDATING VIRTUAL TOUR TO VERSION 0.4.\nParameters:");
-        console.log(parameters);
-        
         if (parameters && parameters.context.behaviour) {
           parameters.context.behaviour.label = {
             showLabel: false,

--- a/upgrades.js
+++ b/upgrades.js
@@ -15,6 +15,9 @@ H5PUpgrades['H5P.ThreeImage'] = (function () {
         finished(null, parameters);
       },
       4: function (parameters, finished) {
+        console.log("UPDATING VIRTUAL TOUR TO VERSION 0.4.\nParameters:");
+        console.log(parameters);
+        
         if (parameters && parameters.behaviour) {
           parameters.behaviour.label = {
             showLabel: false,


### PR DESCRIPTION
Interactions in old Virtual Tours are missing the label settings property. This adds an empty object for the label.