### PR TITLE
Make hotspot act the same as `OpenContent`

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 64,
+  "patchVersion": 65,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/scripts/components/Interactions/HotspotNavButton.js
+++ b/scripts/components/Interactions/HotspotNavButton.js
@@ -1,10 +1,50 @@
+// @ts-check
+
 import React, {useCallback, useEffect, useRef} from 'react';
 import './NavigationButton.scss';
 import { H5PContext } from "../../context/H5PContext";
 
+/**
+ * @typedef {{
+ *   isHotspotTabbable: boolean;
+ *   setHotspotValues: (newWidth: number, newHeight: number) => void;
+ *   tabIndexValue: number;
+ *   reference: React.RefObject;
+ *   staticScene: boolean;
+ *   ariaLabel: string;
+ *   showHotspotOnHover: boolean;
+ *   onClickEvent: React.MouseEventHandler;
+ *   onDoubleClickEvent: React.MouseEventHandler;
+ *   onMouseDownEvent: React.MouseEventHandler;
+ *   onMouseUpEvent: React.MouseEventHandler;
+ *   onFocusEvent: React.FocusEventHandler;
+ *   onBlurEvent: React.FocusEventHandler;
+ *   getHotspotValues: () => [number, number];
+ * }} Props
+ */
+
+/**
+ * @typedef {{
+ *   anchorDrag: boolean;
+ *   canDrag: boolean;
+ *   camPosYaw: number;
+ *   camPosPitch: number;
+ *   startMousePos: number;
+ *   startMidPoint: number;
+ *   sizeWidth: number;
+ *   sizeHeight: number;
+ * }} State
+ */
+
+/**
+ * @extends {React.Component<Props, State>}
+ */
 export default class HotspotNavButton extends React.Component {
+  /** @param {Props} props */
   constructor(props) {
     super(props);
+
+    /** @type {State} */
     this.state = {
       anchorDrag : false,
       canDrag : false,

--- a/scripts/components/Interactions/NavigationButton.js
+++ b/scripts/components/Interactions/NavigationButton.js
@@ -139,7 +139,9 @@ export const getLabelFromInteraction = (interaction) => {
  * }} State
  */
 
-
+/**
+ * @extends {React.Component<Props, State>}
+ */
 export default class NavigationButton extends React.Component {
   /**
    * @param {Props} props 
@@ -147,15 +149,12 @@ export default class NavigationButton extends React.Component {
   constructor(props) {
     super(props);
 
-    /** @type {Props} */
-    this.props = this.props;
-
     this.navButtonWrapper = React.createRef();
     this.navButton = React.createRef();
     this.expandButton = React.createRef();
     this.onBlur = this.onBlur.bind(this);
     this.onFocus = this.onFocus.bind(this);
-    
+
     /** @type {State} */
     this.state = {
       isFocused: this.props.isFocused,

--- a/scripts/components/Interactions/NavigationButton.scss
+++ b/scripts/components/Interactions/NavigationButton.scss
@@ -112,6 +112,7 @@ $labelWidth: 9em;
       }
     }
   }
+
   .drag {
     width: 3.5em;
     height: 3.5em;
@@ -142,6 +143,15 @@ $labelWidth: 9em;
       transform: translateX(-50%) translateY(50%);
       &:before {
         content: $arrow-verti-scale;
+      }
+    }
+
+    .static-scene & {
+      width: 2em;
+      height: 2em;
+
+      &::before {
+        font-size: 1.25em;
       }
     }
   }

--- a/scripts/components/Interactions/OpenContent.js
+++ b/scripts/components/Interactions/OpenContent.js
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import "./OpenContent.scss";
 import { H5PContext } from "../../context/H5PContext";
+import { scaleOpenContentElement } from "../../utils/open-content-utils";
 
 /**
  * @typedef {{
@@ -218,34 +219,23 @@ export default class OpenContent extends React.Component {
       elementRect: this.openContent.current?.getBoundingClientRect() ?? null,
     });
   };
-  onMouseMove = (event, horizontalDrag) => {    
-    if (!this.state.elementRect) {
-      return;
-    }
-    /** @type {number} */
-    let newSize;
 
-    if (this.props.is3DScene) {
-      // We record the currentMouseposition for everytime the mouse moves
-      const currentMousePosition = horizontalDrag
-        ? event.clientX
-        : event.clientY;
-      
-      /* divStartWidth is the start mouse position subtracted by the midpoint, technically this
-      half the size of the actual div, this is used for keeping the original widtrh of the div
-      everytime we drag */
-      const divStartWidth = this.state.startMousePos - this.state.startMidPoint;
-      newSize = (currentMousePosition - divStartWidth) * 2;
-    } else {
-      const { x: elementX, y: elementY } = this.state.elementRect;
-
-        // We record the currentMouseposition for everytime the mouse moves
-      const currentMousePosition = horizontalDrag
-        ? event.clientX - elementX
-        : event.clientY - elementY;
-      
-      newSize = currentMousePosition;
-    }
+  /**
+   * 
+   * @param {React.MouseEvent} event 
+   * @param {boolean} isHorizontalDrag 
+   */
+  onMouseMove = (event, isHorizontalDrag) => {    
+    const { clientX, clientY } = event;
+    const newSize = scaleOpenContentElement(
+      clientX,
+      clientY,
+      this.props.is3DScene,
+      isHorizontalDrag,
+      this.state.elementRect,
+      this.state.startMousePos,
+      this.state.startMidPoint
+    );
 
     const minimumSize = 64;
     const maximumSize = 512;
@@ -254,14 +244,14 @@ export default class OpenContent extends React.Component {
     if (newSizeIsValid) {
       /*These values are used for inline styling in the div in the render loop,
         updating the div dimensions when the mousemove event fires*/
-      horizontalDrag
+      isHorizontalDrag
         ? this.setState({
             sizeWidth: newSize,
           })
-        : this.setState({ 
+        : this.setState({
             sizeHeight: newSize,
-          }); 
-      }
+          });
+    }
   };
 
   onAnchorDragMouseUp = () => {

--- a/scripts/components/Scene/SceneTypes/StaticScene.js
+++ b/scripts/components/Scene/SceneTypes/StaticScene.js
@@ -344,7 +344,7 @@ export default class StaticScene extends React.Component {
       ? ['disabled']
       : [];
 
-    const imageSceneClasses = ['image-scene-wrapper'];
+    const imageSceneClasses = ['image-scene-wrapper', 'static-scene'];
     if (this.state.isVerticalImage) {
       imageSceneClasses.push('vertical');
     }
@@ -440,6 +440,7 @@ export default class StaticScene extends React.Component {
                   ariaLabel={null}
                   isFocused={this.props.focusedInteraction === index}
                   onBlur={this.props.onBlurInteraction}
+                  is3DScene={false}
                 >
                   {
                     this.context.extras.isEditor &&

--- a/scripts/utils/open-content-utils.js
+++ b/scripts/utils/open-content-utils.js
@@ -1,0 +1,49 @@
+// @ts-check
+
+/**
+ * @param {number} clientX
+ * @param {number} clientY
+ * @param {boolean} is3DScene
+ * @param {boolean} isHorizontalDrag
+ * @param {DOMRect} elementRect
+ * @param {number} startMousePos
+ * @param {number} startMidPoint
+ * @returns {number}
+ */
+export const scaleOpenContentElement = (
+  clientX,
+  clientY,
+  is3DScene,
+  isHorizontalDrag,
+  elementRect,
+  startMousePos,
+  startMidPoint
+) => {
+  if (!elementRect) {
+    return;
+  }
+  /** @type {number} */
+  let newSize;
+
+  if (is3DScene) {
+    // We record the currentMouseposition for everytime the mouse moves
+    const currentMousePosition = isHorizontalDrag ? clientX : clientY;
+
+    /* divStartWidth is the start mouse position subtracted by the midpoint, technically this
+    half the size of the actual div, this is used for keeping the original widtrh of the div
+    everytime we drag */
+    const divStartWidth = startMousePos - startMidPoint;
+    newSize = (currentMousePosition - divStartWidth) * 2;
+  } else {
+    const { x: elementX, y: elementY } = elementRect;
+
+    // We record the currentMouseposition for everytime the mouse moves
+    const currentMousePosition = isHorizontalDrag
+      ? clientX - elementX
+      : clientY - elementY;
+
+    newSize = currentMousePosition;
+  }
+
+  return newSize;
+};


### PR DESCRIPTION
Hotspots act differently when placed in a static scene than when placed in a 3D scene. Scale handles are far too big and the scale effect resizes the element more than the pointer is moved.