### PR TITLE
decrease the minimum hotspot size to 30

### DIFF
--- a/scripts/components/Interactions/HotspotNavButton.js
+++ b/scripts/components/Interactions/HotspotNavButton.js
@@ -123,8 +123,8 @@ export default class HotspotNavButton extends React.Component {
       this.state.startMidPoint
     );
 
-    const minimumSize = 128;
-    const maximumSize = 2048;
+    const minimumSize = 20;
+    const maximumSize = 2000;
 
     const newSizeIsValid = newSize > minimumSize && newSize < maximumSize;
     if (newSizeIsValid) {


### PR DESCRIPTION
Also change the maximum size to a round (in decimal) number, to remove
some confusion. Some might wrongly believe that it's important for
the size to be 2^x, but it's not.