### PR TITLE
fix error where scene description did not show on the first scene

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 71,
+  "patchVersion": 73,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/scripts/components/Main.js
+++ b/scripts/components/Main.js
@@ -64,8 +64,9 @@ export default class Main extends React.Component {
         isEditingInteraction: false
       });
     });
+
     // Show scene description when scene starts for the first time, if specified
-	  if (!this.context.extras.isEditor && this.props.currentScene) {
+	  if (!this.context.extras.isEditor && this.props.currentScene != null) {
       this.handleSceneDescriptionInitially(this.props.currentScene);
     }
     this.setState({scoreCard: this.initialScoreCard()});
@@ -329,7 +330,7 @@ export default class Main extends React.Component {
    *
    * @param {number} sceneId
    */
-   handleSceneDescriptionInitially = (sceneId) => {
+  handleSceneDescriptionInitially = (sceneId) => {
     const prevOpened = this.state.scenesOpened.includes(sceneId);
     if (!prevOpened) {
       // Scene has not been opened before, find scene information


### PR DESCRIPTION
The first scene has id `0`, which is a falsy value in JavaScript.