### PR TITLE
Fix dialog accessibility

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/bg.json
+++ b/language/bg.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/ca.json
+++ b/language/ca.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/cs.json
+++ b/language/cs.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/de.json
+++ b/language/de.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/el.json
+++ b/language/el.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/es.json
+++ b/language/es.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/et.json
+++ b/language/et.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/eu.json
+++ b/language/eu.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/fi.json
+++ b/language/fi.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/fr.json
+++ b/language/fr.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/it.json
+++ b/language/it.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/ko.json
+++ b/language/ko.json
@@ -16,6 +16,9 @@
                   },
                   {
                     "label": "2차원 이미지"
+                  },
+                  {
+                    "label": "Static image"
                   }
                 ]
               },
@@ -35,75 +38,142 @@
                 "label": "장면 설명",
                 "description": "사용자에게 장면을 설명하기 위한 텍스트"
               },
-              {},
               {
+                "label": "Display \"Scene Description\" initially",
+                "description": "Display the scene description when the scene starts for the first time"
+              },
+              {
+                "label": "Initial camera position",
+                "description": "Camera position in pitch and yaw"
+              },
+              {
+                "label": "버튼 형식",
                 "field": {
                   "fields": [
                     {
-                      "label": "라벨",
-                      "description": "빈칸이면 라벨이 표시되지 않으며 화면 읽어주기 기능을 위해 대한 제목 영역을 사용하고자 합니다."
+                      "label": "Label",
+                      "description": "If left blank no label will be displayed and we'll try to use the title field for screen readers"
                     },
                     {
-                      "label": "라벨 설정",
+                      "label": "Label Settings",
                       "fields": [
                         {
-                          "label": "라벨 위치",
-                          "description": "라벨 위치",
+                          "label": "Label position",
+                          "description": "Choose where the label should appear",
                           "options": [
                             {
-                              "label": "행동설정 사용"
+                              "label": "Use behavioral setting"
                             },
                             {
-                              "label": "우측 정렬"
+                              "label": "Right aligned"
                             },
                             {
-                              "label": "좌측 정렬"
+                              "label": "Left aligned"
                             },
                             {
-                              "label": "위쪽 정렬"
+                              "label": "Top aligned"
                             },
                             {
-                              "label": "아래쪽 정렬"
+                              "label": "Bottom aligned"
                             }
                           ]
                         },
                         {
-                          "label": "라벨 표시",
-                          "description": "숨겨진 경우 - 라벨은 마우스 커서 위에 표시됩니다.",
+                          "label": "Display Label",
+                          "description": "If hidden - labels will show only on mouse over",
                           "options": [
                             {
-                              "label": "행동설정 사용"
+                              "label": "Use behavioral setting"
                             },
                             {
-                              "label": "보이기"
+                              "label": "Show"
                             },
                             {
-                              "label": "숨기기"
+                              "label": "Hide"
                             }
                           ]
+                        },
+                        {
+                          "label": "Show as hotspot",
+                          "description": "Allows for adding interaction areas to the background image that can be custom size."
+                        },
+                        {
+                          "label": "Show hotspot when mouse is hovering",
+                          "description": "Will allow hotspot to be visible when mouse is hovering the area."
+                        },
+                        {
+                          "label": "Set the hotspot be tabbable",
+                          "description": "Will allow hotspot to be tabbable. Can be used for accessibilty."
+                        },
+                        {
+                          "label": "Show as open content in the scene",
+                          "description": "Allows the content to be shown in an open dialog box directly in the scene."
+                        },
+                        {
+                          "default": "256,128",
+                          "label": "Values for storing the height and width for hotspot"
+                        },
+                        {
+                          "label": "Code for the interaction",
+                          "description": "If not empty, the user has to input the code in order to open this content."
+                        },
+                        {
+                          "label": "A hint for the interaction code",
+                          "description": "An optional hint for the code, can be left empty if wanted"
                         }
                       ]
                     },
                     {},
-                    {}
+                    {},
+                    {
+                      "label": "Button style",
+                      "description": "Decide how the icon should look.",
+                      "options": [
+                        {
+                          "label": "Text icon"
+                        },
+                        {
+                          "label": "Info icon"
+                        }
+                      ]
+                    }
                   ]
                 }
               },
               {
-                "label": "버튼 형식",
-                "description": "이 장면을 가리키는 단추의 모양을 결정합니다. 정적이고 새로운 장면으로 이어지지 않는 장면의 경우, \"More information\" (더 보기) 버튼을 권장합니다.",
+                "label": "오디오 트랙",
+                "description": "이 장면에 맞는 오디오 트랙을 추가합니다.",
                 "options": [
                   {
-                    "label": "새 장면 (화살표)"
+                    "label": "New scene (arrow)"
                   },
                   {
-                    "label": "더 보기 (플러스)"
+                    "label": "More information (plus)"
                   }
                 ]
               },
               {
-                "label": "오디오 트랙",
-                "description": "이 장면에 맞는 오디오 트랙을 추가합니다."
+                "label": "Audio type",
+                "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
+                "options": [
+                  {
+                    "label": "Audio Track"
+                  },
+                  {
+                    "label": "Playlist"
+                  }
+                ]
+              },
+              {
+                "label": "Audio Track",
+                "description": "Add an audio track that's specific for this scene."
+              },
+              {
+                "label": "Playlist",
+                "description": "Here you can pick an existing playlist as audio."
+              },
+              {
+                "label": "Restart audio when scene is reopened"
               }
             ]
           }
@@ -111,6 +181,22 @@
         {},
         {
           "label": "오디오 트랙"
+        },
+        {
+          "label": "Playlists",
+          "field": {
+            "fields": [
+              {
+                "label": "Playlist Title",
+                "description": "Used to identify the playlist"
+              },
+              {
+                "label": "Audio Tracks",
+                "description": "Add audio tracks to the playlist."
+              },
+              {}
+            ]
+          }
         }
       ]
     },
@@ -168,34 +254,77 @@
     },
     {
       "label": "라벨 맞춤 설정",
+      "description": "These options will let you control how the world behaves.",
       "fields": [
         {
           "label": "콘텐츠 유형",
-          "default": "가상 여행"
+          "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
+          "options": [
+            {
+              "label": "Global Audio"
+            },
+            {
+              "label": "Playlist"
+            }
+          ]
         },
         {
           "label": "오디오 재생 라벨",
-          "default": "오디오 재생"
+          "description": "Add an audio track that's available for all of the scenes by default."
         },
         {
           "label": "오디오 일시멈출 라벨",
-          "default": "오디오 일시멈춤"
+          "description": "Here you can pick an existing playlist as audio."
         },
         {
           "label": "장면 대화 제목",
-          "default": "장면 설명"
+          "description": "Display button for showing the scores from assignments."
         },
         {
           "label": "카메라 리셋 버튼에 대한 라벨",
-          "default": "카메라 리셋"
+          "description": "Display button for going to start scene."
         },
         {
           "label": "제출 대화상자 라벨",
-          "default": "제출 대화상자"
+          "description": "Choose the amount of width and height segments used to render a scene. This directly affects the quality level of the scene, try increasing the quality if a scene looks \"blocky\" or \"waves\" are seen within the scenes. Note that higher quality rendering takes more time to load.",
+          "options": [
+            {
+              "label": "High Quality (128x128)"
+            },
+            {
+              "label": "Medium Quality (64x64)"
+            },
+            {
+              "label": "Low Quality (16x16)"
+            }
+          ]
         },
         {
           "label": "대화상자 닫기 라벨",
-          "default": "대화상자 닫기"
+          "fields": [
+            {
+              "label": "Label position",
+              "description": "The default label position. The position may be overriden per interaction",
+              "options": [
+                {
+                  "label": "Right aligned"
+                },
+                {
+                  "label": "Left aligned"
+                },
+                {
+                  "label": "Top aligned"
+                },
+                {
+                  "label": "Bottom aligned"
+                }
+              ]
+            },
+            {
+              "label": "Display Labels",
+              "description": "If unchecked - labels will show only on mouse over"
+            }
+          ]
         },
         {
           "label": "확장 버튼 라벨",
@@ -208,6 +337,155 @@
         {
           "label": "내용이 없을 때 라벨",
           "default": "내용 없음"
+        }
+      ]
+    },
+    {
+      "label": "Localize",
+      "fields": [
+        {
+          "label": "Aria label for content type",
+          "default": "Virtual Tour"
+        },
+        {
+          "label": "Label for to play audio",
+          "default": "Play Audio Track"
+        },
+        {
+          "label": "Label to pause audio",
+          "default": "Pause Audio Track"
+        },
+        {
+          "label": "Title to scene dialog",
+          "default": "Scene Description"
+        },
+        {
+          "label": "Label for button to reset camera",
+          "default": "Reset Camera"
+        },
+        {
+          "label": "Label for the submit dialog button",
+          "default": "Submit Dialog"
+        },
+        {
+          "label": "Label for the close dialog button",
+          "default": "Close Dialog"
+        },
+        {
+          "label": "Aria label for the expand label button",
+          "default": "Expand the visual label"
+        },
+        {
+          "label": "Label for when background image is loading in 360 scene",
+          "default": "Loading background image..."
+        },
+        {
+          "label": "Label for when there is no content",
+          "default": "No content"
+        },
+        {
+          "label": "Label for context menu button for go to scene",
+          "default": "Go to scene"
+        },
+        {
+          "label": "Label for context menu button for edit",
+          "default": "Edit"
+        },
+        {
+          "label": "Label for context menu button for delete",
+          "default": "Delete"
+        },
+        {
+          "label": "Translation for \"Score\"",
+          "default": "Score"
+        },
+        {
+          "label": "Translation for \"Assignment\"",
+          "default": "Assignment"
+        },
+        {
+          "label": "Translation for \"Total\"",
+          "default": "Total"
+        },
+        {
+          "label": "Translation for \"Total Score\"",
+          "default": "Total Score"
+        },
+        {
+          "label": "Label for button to show score summary",
+          "default": "Show Score Summary"
+        },
+        {
+          "label": "Translation for 'Scene'",
+          "default": "Scene"
+        },
+        {
+          "label": "Untitled",
+          "default": "Untitled"
+        },
+        {
+          "label": "Go to start scene",
+          "default": "Go to start scene"
+        },
+        {
+          "label": "You are at the start scene",
+          "default": "You are at the start scene"
+        },
+        {
+          "label": "Unlocked",
+          "default": "Unlocked"
+        },
+        {
+          "label": "Locked",
+          "default": "Locked"
+        },
+        {
+          "label": "Search the room until you find the code",
+          "default": "Search the room until you find the code"
+        },
+        {
+          "label": "The code was wrong, try again.",
+          "default": "The code was wrong, try again."
+        },
+        {
+          "label": "The content has been unlocked!",
+          "default": "The content has been unlocked!"
+        },
+        {
+          "label": "Code",
+          "default": "Code"
+        },
+        {
+          "label": "Show code",
+          "default": "Show code"
+        },
+        {
+          "label": "Hide code",
+          "default": "Hide code"
+        },
+        {
+          "label": "Unlocked interaction action (Continue)",
+          "default": "Continue"
+        },
+        {
+          "label": "Locked interaction action (Unlock)",
+          "default": "Unlock"
+        },
+        {
+          "label": "Drag horizontally to scale (for screen readers)",
+          "default": "Drag horizontally to scale"
+        },
+        {
+          "label": "Drag vertically to scale (for screen readers)",
+          "default": "Drag vertically to scale"
+        },
+        {
+          "label": "Hint",
+          "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/nb.json
+++ b/language/nb.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/nl.json
+++ b/language/nl.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/nn.json
+++ b/language/nn.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/sl.json
+++ b/language/sl.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/language/sv.json
+++ b/language/sv.json
@@ -428,6 +428,10 @@
         {
           "label": "Hint",
           "default": "Hint"
+        },
+        {
+          "label": "Locked content",
+          "default": "Locked content"
         }
       ]
     }

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -62,6 +62,7 @@ H5P.NDLAThreeImage = (function () {
       backgroundLoading: 'Loading background image...',
       noContent: 'No content',
       hint: 'Hint',
+      lockedContent: 'Locked content',
       ...params.l10n,
     };
 
@@ -116,6 +117,7 @@ H5P.NDLAThreeImage = (function () {
             setCurrentSceneId={setCurrentSceneId}
             addThreeSixty={ tS => this.threeSixty = tS }
             onSetCameraPos={setCameraPosition}
+            isVeryFirstRender={ true }
           />
         </H5PContext.Provider>,
         wrapper

--- a/scripts/components/Dialog/Dialog.js
+++ b/scripts/components/Dialog/Dialog.js
@@ -1,17 +1,44 @@
 import React from 'react';
 import './Dialog.scss';
+import FocusTrap from '../../utils/focus-trap';
 import { H5PContext } from "../../context/H5PContext";
 
 export default class Dialog extends React.Component {
   constructor(props) {
     super(props);
+
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   componentDidMount() {
-    // Focus must be set to the first focusable element, if it contains password, <PasswordContent/> sets the focus to its input field
-    if (this.props.focusOnTitle) {
-      this.title.focus();
-    }
+    /*
+     * Focus trap to keep focus inside dialog modal. Will focus first tabbable
+     * element if `takeFocus` is true (= default except for first page load).
+     */
+    this.initializeFocusTrap();
+
+    // Handle Escape key to close dialog as dialog modal should
+    window.addEventListener('keydown', this.handleKeyDown);
+  }
+
+  /**
+   * Handle React component will unmount.
+   */
+  componentWillUnmount() {
+    this.focusTrap.deactivate();
+    window.removeEventListener('keydown', this.handleKeyDown);
+  }
+
+  /**
+   * Initialize focus trap.
+   */
+  initializeFocusTrap() {
+    this.focusTrap = new FocusTrap({
+      trapElement: this.el,
+      takeFocus: this.props.takeFocus
+    });
+
+    this.focusTrap.activate();
   }
 
   handleDialogRef = (el) => {
@@ -24,6 +51,17 @@ export default class Dialog extends React.Component {
     if (this.el) {
       this.el.style.width = '';
       this.el.style.height = this.el.getBoundingClientRect().height + 'px';
+    }
+  };
+
+  /**
+   * Handle keydown on dialog.
+   *
+   * @param {KeyboardEvent} event Keyboard event.
+   */
+  handleKeyDown(event) {
+    if (event.code === 'Escape') {
+      this.props.onHideTextDialog();
     }
   }
 
@@ -40,21 +78,27 @@ export default class Dialog extends React.Component {
     ));
 
     return (
-      <div className='h5p-text-overlay' role="dialog" aria-label={ this.props.title }>
-        <div
-          ref={ el => this.title = el }
-          className="h5p-dialog-focusstart"
-          tabIndex="-1"
-        ></div>
+      <div
+        className='h5p-text-overlay'
+        role={ this.props.ariaRole }
+        aria-labelledby={ 'h5p-dialog-label' }
+        aria-describedby={ this.props.ariarole === 'alertdialog' ? 'h5p-dialog-description' : undefined }
+        aria-modal={ 'true' }
+        ref={ this.overlayRef }
+        onKeyDown={ this.handleKeyDown }
+      >
+        <div id='h5p-dialog-label' className="h5p-dialog-label">
+          { this.props.title }
+        </div>
         <div className={dialogClasses.join(' ')} ref={ this.handleDialogRef }>
-          <div className='h5p-text-content'>
+          <div id='h5p-dialog-description' className='h5p-text-content'>
             { children }
           </div>
           <button
             ref={ el => this.closeButton = el }
             aria-label={ this.context.l10n.closeDialog }
             className='close-button-wrapper'
-            onClick={this.props.onHideTextDialog}
+            onClick={ this.props.onHideTextDialog }
           />
         </div>
       </div>

--- a/scripts/components/Dialog/Dialog.scss
+++ b/scripts/components/Dialog/Dialog.scss
@@ -23,6 +23,15 @@
   background: #d6d6d6;
 }
 
+.h5p-dialog-label {
+  height: 1px;
+  left: -10000px;
+  overflow: hidden;
+  position: absolute;
+  top: auto;
+  width: 1px;
+}
+
 .h5p-text-dialog {
   position: absolute;
   transform: translate(-50%, -50%);

--- a/scripts/components/Dialog/PasswordContent.js
+++ b/scripts/components/Dialog/PasswordContent.js
@@ -54,9 +54,6 @@ export default class PasswordContent extends React.Component {
       });
     }, 500);
   };
-  componentDidMount(){
-    this.inputRef.setFocus()
-  }
 
   render() {
     return (
@@ -76,14 +73,14 @@ export default class PasswordContent extends React.Component {
             } ${this.state.shakeClass}`}
           />
         </div>
-        <h1>
+        <div className='h1'>
           {this.state.unlocked
             ? this.context.l10n.unlocked
             : this.context.l10n.locked}
-        </h1>
+        </div>
 
         {
-          <span 
+          <span
             className={`h5p-field-description ${
               this.state.unlocked
                 ? "h5p-field-description--correct-code"

--- a/scripts/components/Dialog/PasswordContent.scss
+++ b/scripts/components/Dialog/PasswordContent.scss
@@ -8,6 +8,15 @@
   max-width: 90%;
   margin: 0.5em auto 0 auto;
 
+  .h1 {
+    font-size: 2em;
+    margin-block-start: 0.67em;
+    margin-block-end: 0.67em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
+
   .h5p-password-icon-wrapper {
     background-color: $activeBorder;
     height: 72px;

--- a/scripts/components/Interactions/NavigationButton.js
+++ b/scripts/components/Interactions/NavigationButton.js
@@ -32,7 +32,7 @@ const infoInteractions = [
 ];
 
 /**
- * @param {string} machineName 
+ * @param {string} machineName
  * @returns {boolean}
  */
 const isInfoInteraction = (machineName) => {
@@ -40,8 +40,8 @@ const isInfoInteraction = (machineName) => {
 };
 
 /**
- * @param {Interaction} interaction 
- * @param {Array<SceneParams>} scenes 
+ * @param {Interaction} interaction
+ * @param {Array<SceneParams>} scenes
  * @returns {string}
  */
 export const getIconFromInteraction = (interaction, scenes) => {
@@ -87,7 +87,7 @@ export const getIconFromInteraction = (interaction, scenes) => {
 };
 
 /**
- * @param {Interaction} interaction 
+ * @param {Interaction} interaction
  * @returns {InteractionLabel}
  */
 export const getLabelFromInteraction = (interaction) => {
@@ -144,7 +144,7 @@ export const getLabelFromInteraction = (interaction) => {
  */
 export default class NavigationButton extends React.Component {
   /**
-   * @param {Props} props 
+   * @param {Props} props
    */
   constructor(props) {
     super(props);
@@ -167,8 +167,8 @@ export default class NavigationButton extends React.Component {
 
   resizeOnDrag = (width, height) => {
     this.setHotspotValues(width, height);
-    
-    if (this.context.extras.isEditor) { 
+
+    if (this.context.extras.isEditor) {
       this.forceUpdate();
     }
   }
@@ -195,7 +195,7 @@ export default class NavigationButton extends React.Component {
   }
 
   /**
-   * @param {FocusEvent} event 
+   * @param {FocusEvent} event
    */
   onBlur(event) {
     const navButtonWrapper = this.navButtonWrapper
@@ -230,7 +230,7 @@ export default class NavigationButton extends React.Component {
   }
 
   /**
-   * @param {Props} prevProps 
+   * @param {Props} prevProps
    */
   componentDidUpdate(prevProps) {
     if (this.props.type && this.props.type === this.props.nextFocus && prevProps.nextFocus !== this.props.nextFocus) {
@@ -332,18 +332,18 @@ export default class NavigationButton extends React.Component {
     if (preventCameraMovement && this.context.threeSixty) {
       this.context.threeSixty.setPreventCameraMovement(true);
     }
-    const isFocusable = this.context.extras.isEditor
-      && this.navButtonWrapper
-      && this.navButtonWrapper.current;
+
+    const isFocusable = !this.context.extras.isEditor
+      && this.navButton?.current;
     if (isFocusable) {
-      this.navButtonWrapper.current.focus({
+      this.navButton.current.focus({
         preventScroll: true
       });
     }
   }
 
   /**
-   * @param {React.FocusEvent<HTMLElement>} event 
+   * @param {React.FocusEvent<HTMLElement>} event
    */
   handleFocus = (event) => {
     if (this.context.extras.isEditor) {
@@ -383,8 +383,8 @@ export default class NavigationButton extends React.Component {
   }
 
   /**
-   * @param {number} widthX 
-   * @param {number} heightY 
+   * @param {number} widthX
+   * @param {number} heightY
    */
   setHotspotValues(widthX, heightY) {
     const scene = this.context.params.scenes.find(
@@ -403,10 +403,10 @@ export default class NavigationButton extends React.Component {
 
   /**
    * @private
-   * 
+   *
    * Returns the current Interaction,
    * based on current scene id and current interaction id.
-   * 
+   *
    * @returns {Interaction}
    */
   getCurrentInteraction() {
@@ -419,7 +419,7 @@ export default class NavigationButton extends React.Component {
   render() {
     const interaction = this.getCurrentInteraction();
     const [_, libraryName] = interaction ? H5P.libraryFromString(interaction?.action?.library).machineName?.split(".") : [null];
-    
+
     let wrapperClasses = interaction ? [
       'nav-button-wrapper',
       `nav-button-wrapper--${libraryName.toLowerCase()}`,
@@ -436,7 +436,7 @@ export default class NavigationButton extends React.Component {
 
     if (interaction?.isAnswered) {
       wrapperClasses.push('h5p-interaction-answered');
-    } 
+    }
 
     if (this.props.is3d) {
       wrapperClasses = wrapperClasses.concat("nav-btn-hotspot render-in-3d");
@@ -494,7 +494,7 @@ export default class NavigationButton extends React.Component {
         this.setHotspotValues(width, height);
       }
     }
-    
+
     return (
       <div
         ref={this.navButtonWrapper}

--- a/scripts/components/Scene/Scene.js
+++ b/scripts/components/Scene/Scene.js
@@ -17,6 +17,7 @@ export const SceneTypes = {
  *   isActive: boolean;
  *   isHiddenBehindOverlay: boolean;
  *   nextFocus: string;
+ *   takeFocus: boolean;
  *   sceneIcons: { id: number; iconType: string; }[];
  *   imageSrc: string;
  *   navigateToScene: () => void;
@@ -44,7 +45,7 @@ export const SceneTypes = {
 
 export default class Scene extends React.Component {
   /**
-   * @param {Props} props 
+   * @param {Props} props
    */
   constructor(props) {
     super(props);
@@ -57,6 +58,7 @@ export default class Scene extends React.Component {
           isActive={this.props.isActive}
           isHiddenBehindOverlay={ this.props.isHiddenBehindOverlay }
           nextFocus={ this.props.nextFocus }
+          takeFocus={ this.props.takeFocus }
           sceneParams={this.props.sceneParams}
           imageSrc={this.props.imageSrc}
           navigateToScene={this.props.navigateToScene.bind(this)}
@@ -80,6 +82,7 @@ export default class Scene extends React.Component {
         isActive={this.props.isActive}
         isHiddenBehindOverlay={ this.props.isHiddenBehindOverlay }
         nextFocus={ this.props.nextFocus }
+        takeFocus={ this.props.takeFocus }
         sceneIcons={this.props.sceneIcons}
         sceneParams={this.props.sceneParams}
         addThreeSixty={ this.props.addThreeSixty }

--- a/scripts/components/Scene/SceneTypes/StaticScene.js
+++ b/scripts/components/Scene/SceneTypes/StaticScene.js
@@ -74,7 +74,7 @@ export default class StaticScene extends React.Component {
     const defaultSize = 938;
     const defaultFontSize = 16;
     this.sceneWrapperRef.current.style.width = `100%`;
-    
+
     // Specific to Firefox - Interaction buttons are moving out of scope when image is potrait
     if (this.imageElementRef.current.clientWidth > 0) {
       this.sceneWrapperRef.current.style.width = `${this.imageElementRef.current.clientWidth}px`;
@@ -281,7 +281,8 @@ export default class StaticScene extends React.Component {
     this.setState({
       isVerticalImage: ratio < this.context.getRatio(),
     });
-    imageElement.focus();
+
+    this.focusScene();
 
     this.context.on('resize', () => {
       staticSceneWidth = imageElement.clientWidth;
@@ -291,6 +292,16 @@ export default class StaticScene extends React.Component {
         isVerticalImage: ratio < this.context.getRatio(),
       });
     });
+  }
+
+  /**
+   * Focus scene.
+   */
+  focusScene() {
+    // Scene should only take focus if nothing else could
+    if (this.props.takeFocus) {
+      this.imageElementRef.current?.focus();
+    }
   }
 
   // Since some interactions don't have titles this seeks to use the closest thing to a title to prevent "Untitled Text"

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -37,7 +37,7 @@ export const sceneRenderingQualityMapping = {
  *  sceneIcons: { id: number; iconType: string; }[];
  *  updateThreeSixty: boolean;
  *  isEditingInteraction: boolean;
- * }} Props 
+ * }} Props
  */
 
 /** @type {ThreeSixtyScene extends React.Component<Props>} */
@@ -67,7 +67,7 @@ export default class ThreeSixtyScene extends React.Component {
 
   /**
    * @private
-   * 
+   *
    * Locks the dragged Navigation Button to the pointer
    * @param {HTMLElement} element
    */
@@ -92,7 +92,7 @@ export default class ThreeSixtyScene extends React.Component {
 
   /**
    * @private
-   * 
+   *
    * Unlocks the Navigation Button from the pointer.
    */
   cancelPointerLock() {
@@ -106,7 +106,7 @@ export default class ThreeSixtyScene extends React.Component {
    * @private
    *
    * Called when the scene is moved, caused by a drag event.
-   * 
+   *
    * @param {H5PEvent} event
    */
    handleSceneMoveStart = (event) => {
@@ -142,10 +142,10 @@ export default class ThreeSixtyScene extends React.Component {
 
   /**
    * @private
-   * 
+   *
    * Since some interactions don't have titles,
    * this seeks to use the closest thing to a title to prevent "Untitled Text"
-   * 
+   *
    * @param {Action} action
    */
   getInteractionTitle(action) {
@@ -162,7 +162,7 @@ export default class ThreeSixtyScene extends React.Component {
 
   /**
    * @private
-   * 
+   *
    * Called when a scene move is stopped after dragging ends.
    */
   handleSceneMoveStop = (e) => {
@@ -174,7 +174,7 @@ export default class ThreeSixtyScene extends React.Component {
 
   /**
    * @private
-   * 
+   *
    * Creates a ThreeSixty object. If one exists uses that one.
    * Apply all listeners
    */
@@ -219,22 +219,32 @@ export default class ThreeSixtyScene extends React.Component {
       this.setState({
         isRendered: true
       });
-      threeSixty.focus();
+
+      this.focusScene();
     });
 
     threeSixty.startRendering();
     if(this.props.isPanorama){
-      threeSixty.updateCylinder();  
+      threeSixty.updateCylinder();
     } else {
       threeSixty.update();
     }
-    
 
     threeSixty.on('movestart', this.handleSceneMoveStart);
     threeSixty.on('movestop', this.handleSceneMoveStop);
 
     // Add buttons to scene
     this.addInteractionHotspots(threeSixty, this.props.sceneParams.interactions);
+  }
+
+  /**
+   * Focus
+   */
+  focusScene() {
+    // Scene should only take focus if nothing else could
+    if (this.props.takeFocus) {
+      this.props.threeSixty?.focus();
+    }
   }
 
   /**
@@ -269,7 +279,7 @@ export default class ThreeSixtyScene extends React.Component {
 
   /**
    * @private
-   * 
+   *
    * Triggeered when the scene is loaded.  Updates state.threeSixty in Main.js
    */
   sceneLoaded = () => {
@@ -286,7 +296,7 @@ export default class ThreeSixtyScene extends React.Component {
 
   /**
    * @private
-   * 
+   *
    * Create, add and render all interactions in the 3D world.
    *
    * @param {Array} interactions
@@ -309,7 +319,7 @@ export default class ThreeSixtyScene extends React.Component {
     }
 
     this.renderedInteractions = list.length;
-    
+
     /** @type {[HTMLElement, HTMLElement]} */
     const [rendererElement2d, rendererElement3d] = threeSixty.getRenderers();
 
@@ -325,12 +335,12 @@ export default class ThreeSixtyScene extends React.Component {
         { components3d }
       </H5PContext.Provider>,
       /** @type {HTMLElement} */ (rendererElement3d.firstChild),
-    );    
+    );
   }
 
   /**
    * @private
-   * 
+   *
    * Creates a button for each interaction
    *
    * @param {Interaction} interaction
@@ -357,7 +367,7 @@ export default class ThreeSixtyScene extends React.Component {
       title = this.getInteractionTitle(interaction.action);
     }
 
-    const onMount = (/** @type {HTMLElement} */ element) => { 
+    const onMount = (/** @type {HTMLElement} */ element) => {
       element.dataset.interactionId = interaction.id;
 
       this.props.threeSixty.add(
@@ -373,15 +383,15 @@ export default class ThreeSixtyScene extends React.Component {
 
     const onUpdate = (/** @type {HTMLElement} */ element) => {
       const threeElement = this.props.threeSixty.find(element);
-      
+
       H5P.NDLAThreeSixty.setElementPosition(
         threeElement,
         ThreeSixtyScene.getPositionFromString(interaction.interactionpos)
       );
     }
-    
+
     const key = interaction.id || `interaction-${this.props.sceneId}${index}`
-    
+
     const is3d = renderIn3d(interaction);
 
     const component = (
@@ -471,7 +481,7 @@ export default class ThreeSixtyScene extends React.Component {
 
   /**
    * @private
-   * 
+   *
    * Convert params position string.
    * TODO: Use object in params instead of convert all the time.
    *
@@ -489,7 +499,7 @@ export default class ThreeSixtyScene extends React.Component {
 
   /**
    * @private
-   * 
+   *
    * Handle interaction focused.
    *
    * @param {Interaction} interaction
@@ -594,7 +604,7 @@ export default class ThreeSixtyScene extends React.Component {
 
       if (shouldUpdateInteractionHotspots) {
         this.addInteractionHotspots(this.props.threeSixty, this.props.sceneParams.interactions);
-      }      
+      }
       // Check if the scene that interactions point to has changed icon type
       // This is only relevant when changing the icon using the H5P editor
       // @ts-ignore
@@ -628,7 +638,7 @@ export default class ThreeSixtyScene extends React.Component {
     if (!this.props.isActive) {
       return null;
     }
-    
+
     return (
       <div className='three-sixty-scene-wrapper'>
         <div

--- a/scripts/utils/focus-trap.js
+++ b/scripts/utils/focus-trap.js
@@ -1,0 +1,182 @@
+export default class FocusTrap {
+
+  /**
+   * Simple focus trap.
+   *
+   * @class
+   * @param {object} [params={}] Parameters.
+   * @param {HTMLElement} params.trapElement Element to be made a trap.
+   * @param {HTMLElement} [params.initialFocus] Element to get initial focus.
+   * @param {boolean} [params.takeFocus=true] If false, don't focus itself.
+   */
+  constructor(params = {}) {
+    params.takeFocus = params.takeFocus ?? true;
+
+    this.handleKeydownEvent = this.handleKeydownEvent.bind(this);
+
+    this.attachTo(params);
+  }
+
+  /**
+   * Attach focus trap.
+   *
+   * @param {object} [params={}] Parameters.
+   * @param {HTMLElement} params.trapElement Element to be made a trap.
+   * @param {HTMLElement} [params.initialFocus] Element to get initial focus.
+   */
+  attachTo(params = {}) {
+    this.params = params;
+    this.focusableElements = [];
+  }
+
+  /**
+   * Activate.
+   */
+  activate() {
+    if (!this.params.trapElement) {
+      return;
+    }
+
+    if (this.isActivated) {
+      return;
+    }
+
+    this.isActivated = true;
+
+    window.requestIdleCallback(() => {
+      this.observer = this.observer || new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting) {
+          this.observer.unobserve(this.params.trapElement);
+
+          this.handleVisible();
+        }
+      }, {
+        root: document.documentElement,
+        threshold: 0
+      });
+      this.observer.observe(this.params.trapElement);
+    });
+  }
+
+  /**
+   * Deactivate.
+   */
+  deactivate() {
+    if (!this.isActivated) {
+      return;
+    }
+
+    this.observer.unobserve(this.params.trapElement);
+
+    this.params.trapElement.removeEventListener('keydown', this.handleKeydownEvent, true);
+    this.isActivated = false;
+  }
+
+  /**
+   * Update list of focusable elements.
+   */
+  updateFocusableElements() {
+    if (!this.params.trapElement) {
+      return;
+    }
+
+    const focusableElementsString = [
+      'a[href]:not([disabled])',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'video',
+      'audio',
+      '[tabindex]:not([tabindex="-1"])'
+    ].join(', ');
+
+    this.focusableElements = []
+      .slice
+      .call(this.params.trapElement.querySelectorAll(focusableElementsString))
+      .filter((element) => {
+        return element.getAttribute('disabled') !== 'true' &&
+          element.getAttribute('disabled') !== true;
+      });
+  }
+
+  /**
+   * Check whether HTML element is child of trap.
+   *
+   * @param {HTMLElement} element Element to check.
+   * @returns {boolean} True, if element is child.
+   */
+  isChild(element) {
+    if (!this.params.trapElement) {
+      return false;
+    }
+
+    const parent = element.parentNode;
+
+    if (!parent) {
+      return false;
+    }
+
+    if (parent === this.params.trapElement) {
+      return true;
+    }
+
+    return this.isChild(parent);
+  }
+
+  /**
+   * Handle visible.
+   */
+  handleVisible() {
+    this.updateFocusableElements();
+
+    this.params.trapElement.addEventListener(
+      'keydown', this.handleKeydownEvent, true
+    );
+
+    if (this.params.initialFocus && this.isChild(this.params.initialFocus)) {
+      this.currentFocusElement = this.params.initialFocus;
+    }
+
+    if (!this.currentFocusElement && this.focusableElements.length) {
+      this.currentFocusElement = this.focusableElements[0];
+    }
+
+    if (this.currentFocusElement && this.params.takeFocus) {
+      this.currentFocusElement.focus();
+    }
+  }
+
+  /**
+   * Handle keyboard event.
+   *
+   * @param {KeyboardEvent} event Keyboard event.
+   */
+  handleKeydownEvent(event) {
+    // Some previously available elements may have an updated tabindex
+    this.updateFocusableElements();
+
+    if (!this.focusableElements.length) {
+      return;
+    }
+
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    event.preventDefault();
+
+    const index = this.focusableElements.findIndex((element) => {
+      return element === this.currentFocusElement;
+    });
+
+    const length = this.focusableElements.length;
+
+    const newIndex = (event.shiftKey) ?
+      (index + length - 1) % length :
+      (index + 1) % length;
+
+    this.currentFocusElement = this.focusableElements[newIndex];
+    this.currentFocusElement.focus();
+  }
+}

--- a/semantics.json
+++ b/semantics.json
@@ -832,6 +832,13 @@
         "label": "Hint",
         "importance": "low",
         "default": "Hint"
+      },
+      {
+        "name": "lockedContent",
+        "type": "text",
+        "label": "Locked content",
+        "importance": "low",
+        "default": "Locked content"
       }
     ]
   }


### PR DESCRIPTION
When merged in, will use `dialog/alertdialog` aria role patterns for the dialog including some related issues that were not mentioned in the a11y report:

- The dialog was not closeable with the `Escape key`
- The focus was not returned properly after closing a dialog
- The whole scene received focus directly after loading which is confusing.
- A proper title was missing for the lock dialog