### PR TITLE
Fix focus trap

### DIFF
--- a/scripts/components/Dialog/Dialog.js
+++ b/scripts/components/Dialog/Dialog.js
@@ -82,9 +82,8 @@ export default class Dialog extends React.Component {
     return (
       <div
         className='h5p-text-overlay'
-        role={ this.props.ariaRole }
+        role='dialog'
         aria-labelledby={ 'h5p-dialog-label' }
-        aria-describedby={ this.props.ariarole === 'alertdialog' ? 'h5p-dialog-description' : undefined }
         aria-modal={ 'true' }
         ref={ this.overlayRef }
         onKeyDown={ this.handleKeyDown }
@@ -93,7 +92,7 @@ export default class Dialog extends React.Component {
           { this.props.title }
         </div>
         <div className={dialogClasses.join(' ')} ref={ this.handleDialogRef }>
-          <div id='h5p-dialog-description' className='h5p-text-content'>
+          <div className='h5p-text-content'>
             { children }
           </div>
           <button

--- a/scripts/components/Dialog/Dialog.js
+++ b/scripts/components/Dialog/Dialog.js
@@ -35,7 +35,9 @@ export default class Dialog extends React.Component {
   initializeFocusTrap() {
     this.focusTrap = new FocusTrap({
       trapElement: this.el,
-      takeFocus: this.props.takeFocus
+      takeFocus: this.props.takeFocus,
+      closeElement: this.closeButton,
+      fallbackContainer: this.el
     });
 
     this.focusTrap.activate();

--- a/scripts/components/Main.js
+++ b/scripts/components/Main.js
@@ -733,7 +733,6 @@ export default class Main extends React.Component {
             onHideTextDialog={this.hideInteraction.bind(this)}
             dialogClasses={dialogClasses}
             takeFocus={ this.isVeryFirstRenderDone }
-            ariaRole={ 'dialog' }
           >
             <PasswordContent
               handlePassword={this.handlePassword.bind(this)}
@@ -752,7 +751,6 @@ export default class Main extends React.Component {
           title={ this.context.l10n.sceneDescription }
           onHideTextDialog={  this.handleCloseTextDialog  }
           takeFocus={ this.isVeryFirstRenderDone }
-          ariaRole={ 'alertdialog' }
         >
           <div dangerouslySetInnerHTML={{__html: this.state.currentText }} />
         </Dialog>

--- a/scripts/utils/focus-trap.js
+++ b/scripts/utils/focus-trap.js
@@ -71,7 +71,7 @@ export default class FocusTrap {
       return;
     }
 
-    this.observer.unobserve(this.params.trapElement);
+    this.observer?.unobserve(this.params.trapElement);
 
     this.params.trapElement.removeEventListener('keydown', this.handleKeydownEvent, true);
     this.isActivated = false;

--- a/scripts/utils/focus-trap.js
+++ b/scripts/utils/focus-trap.js
@@ -146,7 +146,22 @@ export default class FocusTrap {
     }
 
     if (!this.currentFocusElement && this.focusableElements.length) {
-      this.currentFocusElement = this.focusableElements[0];
+      if (
+        this.focusableElements[0] === this.params.closeElement &&
+        this.params.fallbackContainer?.firstChild &&
+        this.focusableElements.length === 1
+      ) {
+        /*
+         * Advisable to set tabindex -1 and focus on static element instead of
+         * focusing the close button and not announcing anything
+         * @see https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
+         */
+        this.params.fallbackContainer.firstChild.setAttribute('tabindex', '-1');
+        this.currentFocusElement = this.params.fallbackContainer.firstChild;
+      }
+      else {
+        this.currentFocusElement = this.focusableElements[0];
+      }
     }
 
     if (this.currentFocusElement && this.params.takeFocus) {

--- a/scripts/utils/focus-trap.js
+++ b/scripts/utils/focus-trap.js
@@ -139,6 +139,8 @@ export default class FocusTrap {
       'keydown', this.handleKeydownEvent, true
     );
 
+    this.currentFocusElement = null;
+
     if (this.params.initialFocus && this.isChild(this.params.initialFocus)) {
       this.currentFocusElement = this.params.initialFocus;
     }


### PR DESCRIPTION
I am not quite sure why this would happen, but I just had two Virtual Tours on screen at the same time, and then the focus trap would not be activated properly and crash, so I added a guard to the observer.

Also: Added some improvement that in line with https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/ sets focus on a non-tabbable element by giving it `tabindex="-1"` (can get focus, but not be tabbed to). That's useful for the scene descriptions.

Aaand then some follow-up simplification. When a text element can get focus as an exception, then there's no need for the `alertdialog` role.