### PR TITLE
Fix static scene size computation on load

### DIFF
--- a/scripts/components/Scene/SceneTypes/StaticScene.js
+++ b/scripts/components/Scene/SceneTypes/StaticScene.js
@@ -282,14 +282,19 @@ export default class StaticScene extends React.Component {
 
     this.focusScene();
 
-    this.context.on('resize', () => {
+    const setStatisSceneSize = () => {
       staticSceneWidth = imageElement.clientWidth;
       staticSceneHeight = imageElement.clientHeight;
 
       this.setState({
         isVerticalImage: ratio < this.context.getRatio(),
       });
+    };
+
+    this.context.on('resize', () => {
+      setStatisSceneSize();
     });
+    setStatisSceneSize();
   }
 
   /**


### PR DESCRIPTION
When a static scene was loaded the static scene size was not computed unless a `resize` event was caught. That lead other components that relied on this size to break (e. g. hotspot resizing).

Fixed by setting the static scene size initially once the scene is loaded, too.