### PR TITLE
Remove unnecessary widget

### DIFF
--- a/build_info/repos
+++ b/build_info/repos
@@ -20,7 +20,6 @@ https://github.com/h5p/h5p-summary.git
 https://github.com/h5p/h5p-transition.git
 https://github.com/h5p/h5p-single-choice-set.git
 https://github.com/h5p/h5p-soundjs.git
-https://github.com/NDLANO/h5p-editor-image-radio-group.git
 https://github.com/NDLANO/h5p-editor-ndla-virtual-tour.git
 https://github.com/NDLANO/h5p-ndla-font-icons.git
 https://github.com/NDLANO/h5p-ndla-virtual-tour.git

--- a/library.json
+++ b/library.json
@@ -50,11 +50,6 @@
       "minorVersion": 1
     },
     {
-      "machineName": "H5PEditor.ImageRadioGroup",
-      "majorVersion": 1,
-      "minorVersion": 0
-    },
-    {
       "machineName": "H5PEditor.ShowWhen",
       "majorVersion": 1,
       "minorVersion": 0

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   "author": "Joubel AS",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 104,
+  "patchVersion": 105,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "h5p-ndla-three-image",
-  "version": "0.4.104",
+  "version": "0.4.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "h5p-ndla-three-image",
-      "version": "0.4.104",
+      "version": "0.4.105",
       "license": "MIT",
       "dependencies": {
         "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h5p-ndla-three-image",
-  "version": "0.4.104",
+  "version": "0.4.105",
   "description": "Create 360 image content",
   "main": "index.js",
   "scripts": {

--- a/semantics.json
+++ b/semantics.json
@@ -296,20 +296,18 @@
                           ]
                         }
                       ],
-                      "widget": "imageRadioGroup"
+                      "widget": "radioGroup"
                     },
                     "alignment": "horizontal",
                     "fontFamily": "360-Image",
                     "options": [
                       {
                         "value": "text-icon",
-                        "label": "Text icon",
-                        "fontIcon": "e91f"
+                        "label": "Text icon"
                       },
                       {
                         "value": "info-icon",
-                        "label": "Info icon",
-                        "fontIcon": "e91a"
+                        "label": "Info icon"
                       }
                     ],
                     "default": "text-icon"


### PR DESCRIPTION
When merged in, will remove a completely unnecessary forked version of the standard radio group editor widget. It's enough to add some extra styling in the Virtual Tour editor library (see https://github.com/NDLANO/h5p-editor-ndla-virtual-tour/pull/24 is required)

Technically, this change here should require a bump in the minor version (to update the library dependencies in the database if I am not mistaken), but there are upcoming changes anyway that will also require to bump the minor version - can as well do it when those are merged in.

The repository https://github.com/NDLANO/h5p-editor-image-radio-group is completely useless then, I think, and could be archived or even deleted.