### PR TITLE
fix: hud buttons tabindex

### DIFF
--- a/scripts/components/HUD/HUD.js
+++ b/scripts/components/HUD/HUD.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import './HUD.scss';
-
 import { H5PContext } from '../../context/H5PContext';
 import AudioButton from './Buttons/AudioButton';
 import Button from './Buttons/Button/Button';
@@ -246,11 +245,17 @@ export default class HUD extends React.Component {
   }
 
   /**
+   * React componentDidUpdate.
+   */
+  componentDidUpdate() {
+    this.addButtonRefs();
+  }
+
+  /**
    * React render function.
    * @returns {object} JSX element.
    */
   render() {
-    this.addButtonRefs();
     const showScoresButton = this.props.showScoresButton;
     const showHomeButton = this.props.showHomeButton;
     const isThreeSixty =

--- a/scripts/components/HUD/HUD.js
+++ b/scripts/components/HUD/HUD.js
@@ -19,14 +19,45 @@ export default class HUD extends React.Component {
       currentButtonIndex: 0
     };
 
-    // This does not feel very React-ish, does it?
-    this.buttons = {
-      'audio': React.createRef(),
-      'scene-description': React.createRef(),
-      'reset': React.createRef(),
-      'go-to-start': React.createRef(),
-      'score-summary': React.createRef()
-    };
+    this.audioButtonRef = React.createRef();
+    this.sceneDescriptionButtonRef = React.createRef();
+    this.resetButtonRef = React.createRef();
+    this.goToStartButtonRef = React.createRef();
+    this.scoreSummaryButtonRef = React.createRef();
+
+    this.buttons = {};
+  }
+
+  /**
+   * Add button refs.
+   */
+  addButtonRefs() {
+    this.buttons = {};
+
+    // Audio button
+    if (this.props.scene.audio) {
+      this.buttons['audio'] = this.audioButtonRef;
+    }
+
+    // Scene description button
+    if (this.props.scene.scenedescription) {
+      this.buttons['scene-description'] = this.sceneDescriptionButtonRef;
+    }
+
+    // Reset button
+    if (this.props.scene.sceneType === SceneTypes.THREE_SIXTY_SCENE) {
+      this.buttons['reset'] = this.resetButtonRef;
+    }
+
+    // Go to start button
+    if (this.props.showHomeButton && !this.props.isStartScene) {
+      this.buttons['go-to-start'] = this.goToStartButtonRef;
+    }
+
+    // Score summary button
+    if (this.props.showScoresButton) {
+      this.buttons['score-summary'] = this.scoreSummaryButtonRef;
+    }
   }
 
   /**
@@ -219,6 +250,7 @@ export default class HUD extends React.Component {
    * @returns {object} JSX element.
    */
   render() {
+    this.addButtonRefs();
     const showScoresButton = this.props.showScoresButton;
     const showHomeButton = this.props.showHomeButton;
     const isThreeSixty =

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -468,9 +468,9 @@ export default class ThreeSixtyScene extends React.Component {
     // Prevent click if user also dragged button beyond maximum slack.
     const endPosition = this.props.threeSixty.getCurrentPosition();
     if (
-      Math.abs(endPosition.yaw - this.startPosition.yaw) >
+      Math.abs(endPosition.yaw - this.startPosition?.yaw) >
         ThreeSixtyScene.MAX_YAW_DELTA ||
-      Math.abs(endPosition.pitch - this.startPosition.pitch) >
+      Math.abs(endPosition.pitch - this.startPosition?.pitch) >
         ThreeSixtyScene.MAX_PITCH_DELTA
     ) {
       return; // Dragged button too much for click


### PR DESCRIPTION
What this PR solves:

Currently, when always adding a key for each button, the tabIndex order will not always be correct. The first button is the audio button and it will always receive tabIndex of 0 and therefore always be the first accessible button in the HUB button group. But if there is no audio file added to the scene, the audio button will not show and the HUD buttons will then never be accessible by keyboard. This is because the rest of the buttons are accessible by arrow keys and will not receive a tabIndex of 0 (instead of -1) until the first button in the group is navigated to. 

In order to get the correct tabIndexes it is better to only add the existing buttons for the current scene to the `buttons` list.