### PR TITLE
feat: limit hotspot height in panorama

### DIFF
--- a/scripts/components/Interactions/HotspotNavButton.js
+++ b/scripts/components/Interactions/HotspotNavButton.js
@@ -40,6 +40,21 @@ export default class HotspotNavButton extends React.Component {
   }
 
   /**
+   * React life-cycle handler: Component did update.
+   * @param {object} prevProps Previous props.
+   */
+  componentDidUpdate(prevProps) {
+    // If changed to panorama, make sure the height does not exceed maximum
+    if (this.props.isPanorama && !prevProps.isPanorama && this.context.isEditor) {
+      if (this.state.sizeHeight > HotspotNavButton.MAX_HEIGHT_PANORAMA) {
+        this.setState({
+          sizeHeight: HotspotNavButton.MAX_HEIGHT_PANORAMA
+        });
+      }
+    }
+  }
+
+  /**
    * Toggle drag state.
    */
   toggleDrag() {
@@ -122,9 +137,12 @@ export default class HotspotNavButton extends React.Component {
           this.setState({ sizeHeight: (newSize / staticSceneHeight) * 100 });
       }
       else {
+        const isPanorma = this.props.isPanorama;
+        const newSizePanorama = Math.min(newSize, HotspotNavButton.MAX_HEIGHT_PANORAMA);
+
         isHorizontalDrag ?
           this.setState({ sizeWidth: newSize }) :
-          this.setState({ sizeHeight: newSize });
+          this.setState({ sizeHeight: isPanorma ? newSizePanorama : newSize });
       }
 
       this.props.resizeOnDrag(this.state.sizeWidth, this.state.sizeHeight);
@@ -254,3 +272,6 @@ HotspotNavButton.SIZE_MIN = 20;
 
 /** @constant {number} SIZE_MAX Maximum size of 3D hotspot */
 HotspotNavButton.SIZE_MAX = 2000;
+
+/** @constant {number} MAX_HEIGHT_PANORAMA Maximum hotspot height in Panorama */
+HotspotNavButton.MAX_HEIGHT_PANORAMA = 800;

--- a/scripts/components/Interactions/NavigationButton.js
+++ b/scripts/components/Interactions/NavigationButton.js
@@ -506,6 +506,7 @@ export default class NavigationButton extends React.Component {
               setHotspotValues={this.setHotspotValues.bind(this)}
               getHotspotValues={this.getHotspotValues.bind(this)}
               staticScene={this.props.staticScene}
+              isPanorama={this.context.extras.isPanorama}
               showHotspotOnHover={this.props.showHotspotOnHover}
               isHotspotTabbable={this.props.isHotspotTabbable}
             />


### PR DESCRIPTION
Limits the height of hotspots in panorama to a static height (could be changed). And sets the max hotspot height when changing from 360 to ensure that the hotspot is not unreachable. 