### PR TITLE
fix: label position when zoomed into static scene

### DIFF
--- a/scripts/components/Interactions/NavigationButton.js
+++ b/scripts/components/Interactions/NavigationButton.js
@@ -540,6 +540,7 @@ export default class NavigationButton extends React.Component {
             navButtonFocused={this.state.innerButtonFocused}
             rendered={this.props.rendered}
             onDoubleClick={this.onDoubleClick.bind(this)}
+            zoomScale={this.props.zoomScale}
           />}
 
       </div>

--- a/scripts/components/Interactions/NavigationButtonLabel.js
+++ b/scripts/components/Interactions/NavigationButtonLabel.js
@@ -214,6 +214,14 @@ export default class NavigationButtonLabel extends React.Component {
    * Set expand properties.
    */
   setExpandProperties() {
+    /*
+     * Only set expand properties when not zoomed in to avoid 
+     * labels toggling when moving image within the wrapper.
+     */
+    if (this.props.zoomScale !== 1) {
+      return;
+    }
+
     const labelProperties = this.getOverflowProperties();
 
     if (labelProperties.expandDirection !== this.state.expandDirection) {


### PR DESCRIPTION
The label position and expand properties can now change when zooming in and moving the static scene image. To prevent this and keep the initial label position and expand properties, we can avoid updating `setExpandProperties` of the label when zoomed in.