### PR TITLE
feat: make open content scale

### DIFF
--- a/scripts/components/Interactions/OpenContent.js
+++ b/scripts/components/Interactions/OpenContent.js
@@ -215,11 +215,10 @@ export default class OpenContent extends React.Component {
    */
   onMouseMove(event, isHorizontalDrag) {
     const { clientX, clientY } = event;
-    const is3d = false; // OpenContent is always 2D
     const newSize = scaleOpenContentElement(
       clientX,
       clientY,
-      is3d,
+      this.props.is3d,
       isHorizontalDrag,
       this.state.elementRect,
       this.state.startMousePos,

--- a/scripts/components/Interactions/OpenContent.js
+++ b/scripts/components/Interactions/OpenContent.js
@@ -218,7 +218,7 @@ export default class OpenContent extends React.Component {
     const newSize = scaleOpenContentElement(
       clientX,
       clientY,
-      this.props.is3d,
+      this.props.is3dScene,
       isHorizontalDrag,
       this.state.elementRect,
       this.state.startMousePos,
@@ -363,17 +363,6 @@ export default class OpenContent extends React.Component {
       height *= this.props.zoomScale;
     }
 
-    if (!this.props.staticScene && this.context.threeSixty) {
-      const defaultFov = this.context.threeSixty.fieldOfView;
-      const currentFov = this.context.threeSixty.camera.fov;
-      const zoomScale = defaultFov / currentFov;
-      
-      if (zoomScale !== 1) {
-        width *= zoomScale;
-        height *= zoomScale;
-      }
-    }
-
     if (this.state.isMouseOver) {
       wrapperClasses.push('hover');
     }
@@ -386,6 +375,10 @@ export default class OpenContent extends React.Component {
     // Add classname to current active element (wrapper, button or expand label button) so it can be shown on top
     if (this.state.isFocused && this.props.children) {
       wrapperClasses.push('active-element');
+    }
+
+    if (this.props.is3d) {
+      wrapperClasses.push('render-in-3d');
     }
 
     const DragButton = (innerProps) => {

--- a/scripts/components/Interactions/OpenContent.js
+++ b/scripts/components/Interactions/OpenContent.js
@@ -363,6 +363,17 @@ export default class OpenContent extends React.Component {
       height *= this.props.zoomScale;
     }
 
+    if (!this.props.staticScene && this.context.threeSixty) {
+      const defaultFov = this.context.threeSixty.fieldOfView;
+      const currentFov = this.context.threeSixty.camera.fov;
+      const zoomScale = defaultFov / currentFov;
+      
+      if (zoomScale !== 1) {
+        width *= zoomScale;
+        height *= zoomScale;
+      }
+    }
+
     if (this.state.isMouseOver) {
       wrapperClasses.push('hover');
     }

--- a/scripts/components/Interactions/OpenContent.js
+++ b/scripts/components/Interactions/OpenContent.js
@@ -158,15 +158,15 @@ export default class OpenContent extends React.Component {
    * Toggle dragging state.
    */
   toggleDrag() {
-    const dragBool = !this.state.canDrag;
-    this.setState({ canDrag: dragBool });
+    const canDrag = this.state.canDrag;
+    this.setState({ canDrag: !canDrag });
 
     if (!this.props.staticScene) {
       /*
        * If we cant drag anymore, we start rendering of threesixty scene, we
        * also set camera position that is stored when we start hotspot scaling
        */
-      if (!this.state.canDrag) {
+      if (canDrag) {
         this.context.threeSixty.startRendering();
         this.context.threeSixty.setCameraPosition(
           this.state.camPosYaw,
@@ -215,10 +215,11 @@ export default class OpenContent extends React.Component {
    */
   onMouseMove(event, isHorizontalDrag) {
     const { clientX, clientY } = event;
+    const is3d = false; // OpenContent is always 2D
     const newSize = scaleOpenContentElement(
       clientX,
       clientY,
-      this.props.is3DScene,
+      is3d,
       isHorizontalDrag,
       this.state.elementRect,
       this.state.startMousePos,

--- a/scripts/components/Interactions/OpenContent.js
+++ b/scripts/components/Interactions/OpenContent.js
@@ -218,7 +218,7 @@ export default class OpenContent extends React.Component {
     const newSize = scaleOpenContentElement(
       clientX,
       clientY,
-      this.props.is3dScene,
+      this.props.is3DScene,
       isHorizontalDrag,
       this.state.elementRect,
       this.state.startMousePos,
@@ -390,7 +390,7 @@ export default class OpenContent extends React.Component {
 
       // Add mouseup listener on document so user can release mouse everywhere
       const handleMouseDown = useCallback((event) => {
-        this.onAnchorDragMouseDown(event, !innerProps.horizontalDrag);
+        this.onAnchorDragMouseDown(event, innerProps.horizontalDrag);
         this.toggleDrag();
         document.addEventListener('mousemove', mouseMoveHandler);
 

--- a/scripts/components/Interactions/OpenContent.scss
+++ b/scripts/components/Interactions/OpenContent.scss
@@ -41,13 +41,13 @@ $labelWidth: 9em;
     &.dragging, &.focused{
       z-index: 3;
     }
-&--editor {
-  /* for "deactivating" a tags so we don't accidentally click them when positioning the content box*/
-  a {
-    pointer-events: none;
-    cursor: default;
-  }
-}
+    &--editor {
+      /* for "deactivating" a tags so we don't accidentally click them when positioning the content box*/
+      a {
+        pointer-events: none;
+        cursor: default;
+      }
+    }
     .drag {
       width: 2em;
       height: 2em;
@@ -79,6 +79,16 @@ $labelWidth: 9em;
         &:before {
           content: $arrow-verti-scale;
         }
+      }
+    }
+  }
+  &.render-in-3d {
+    .open-content .drag {
+      width: 3.5em;
+      height: 3.5em;
+
+      &:before {
+        font-size: 2.25em;
       }
     }
   }

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -382,6 +382,7 @@ export default class ThreeSixtyScene extends React.Component {
           isFocused={this.props.focusedInteraction === index}
           onBlur={this.props.onBlurInteraction}
           is3DScene={true}
+          is3d={is3d}
         >
           {
             this.context.extras.isEditor &&

--- a/scripts/components/Shared/ContextMenu.scss
+++ b/scripts/components/Shared/ContextMenu.scss
@@ -146,3 +146,9 @@
   }
 }
 
+.open-content-wrapper.render-in-3d {
+  .context-menu button {
+    font-size: 1.8em;
+  }
+}
+

--- a/scripts/utils/open-content-utils.js
+++ b/scripts/utils/open-content-utils.js
@@ -29,7 +29,7 @@ export const scaleOpenContentElement = (
     const currentMousePosition = isHorizontalDrag ? clientX : clientY;
 
     /* divStartWidth is the start mouse position subtracted by the midpoint, technically this
-    half the size of the actual div, this is used for keeping the original widtrh of the div
+    half the size of the actual div, this is used for keeping the original width of the div
     everytime we drag */
     const divStartWidth = startMousePos - startMidPoint;
     newSize = (currentMousePosition - divStartWidth) * 2;

--- a/scripts/utils/utils.js
+++ b/scripts/utils/utils.js
@@ -6,7 +6,7 @@ import he from 'he';
  * @returns {boolean} True, if should be rendered in 3D.
  */
 export const renderIn3d = (interaction) => {
-  return interaction.showAsHotspot;
+  return interaction.showAsHotspot || interaction.showAsOpenSceneContent;
 };
 
 /**


### PR DESCRIPTION
- [x] Renders open content in 3d instead of 2d, so that it scales together with the scene. 
- [x] Fixes bug with drag. Using the anchors to resize open content didn't work - it changed the camera position and the user was unable to move the scene view, zoom or interaction with certain elements.
- [x] Corrects the boolean horizontal drag value that's sent to onAnchorDragMouseDown.