### PR TITLE
Fix focus trap not ignoring all tabindex = -1

### DIFF
--- a/scripts/utils/focus-trap.js
+++ b/scripts/utils/focus-trap.js
@@ -90,16 +90,18 @@ export default class FocusTrap {
       'input:not([disabled])',
       'select:not([disabled])',
       'video',
-      'audio',
-      '[tabindex]:not([tabindex="-1"])'
+      'audio'
     ].join(', ');
 
     this.focusableElements = []
       .slice
       .call(this.params.trapElement.querySelectorAll(focusableElementsString))
       .filter((element) => {
-        return element.getAttribute('disabled') !== 'true' &&
-          element.getAttribute('disabled') !== true;
+        return (
+          element.getAttribute('disabled') !== 'true' &&
+          element.getAttribute('disabled') !== true &&
+          element.getAttribute('tabindex') !== '-1'
+        );
       });
   }
 


### PR DESCRIPTION
When merged in, will fix the focus trap ignoring some tabindex = -1 cases. Should now work with version 0.5.8+ of H5P.Crossword.