### PR TITLE
fix: max width of open content in 360

### DIFF
--- a/scripts/components/Interactions/OpenContent.js
+++ b/scripts/components/Interactions/OpenContent.js
@@ -224,9 +224,18 @@ export default class OpenContent extends React.Component {
       this.state.startMousePos,
       this.state.startMidPoint
     );
+  
+    let sizeMax = OpenContent.SIZE_MAX;
+    
+    if (this.props.is3DScene) {
+      sizeMax = OpenContent.SIZE_MAX_360;
+    } 
+    if (this.props.isPanorama) {
+      sizeMax = OpenContent.SIZE_MAX_PANORAMA;
+    }
 
     if (
-      newSize > OpenContent.SIZE_MIN && newSize < OpenContent.SIZE_MAX
+      newSize > OpenContent.SIZE_MIN && newSize < sizeMax
     ) {
       /*
        * These values are used for inline styling in div in render loop,
@@ -485,3 +494,9 @@ OpenContent.SIZE_MIN = 64;
 
 /** @constant {number} SIZE_MAX Maximum size for content. */
 OpenContent.SIZE_MAX = 512;
+
+/** @constant {number} SIZE_MAX_360 Maximum size for 360 content */
+OpenContent.SIZE_MAX_360 = 1024;
+
+/** @constant {number} SIZE_MAX_PANORAMA Maximum size for Panorama content */
+OpenContent.SIZE_MAX_PANORAMA = 720;

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -383,6 +383,7 @@ export default class ThreeSixtyScene extends React.Component {
           onBlur={this.props.onBlurInteraction}
           is3DScene={true}
           is3d={is3d}
+          isPanorama={this.props.isPanorama}
         >
           {
             this.context.extras.isEditor &&


### PR DESCRIPTION
Now that open content is added to the 3D layer the max width should be adjusted accordingly to match the 3D layer.