### PR TITLE
refactor: rename editor repo to escape room

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
 
           if [ -d "h5p-editor-audio-recorder" ]; then pushd h5p-editor-audio-recorder && npm ci && npm run build; popd; fi
 
-          if [ -d "h5p-editor-ndla-virtual-tour" ]; then pushd h5p-editor-ndla-virtual-tour && npm ci && npm run build; popd; fi
+          if [ -d "h5p-editor-escape-room" ]; then pushd h5p-editor-escape-room && npm ci && npm run build; popd; fi
 
           cp -r ../h5p-ndla-virtual-tour .
       - name: Use Node.js

--- a/build_info/repos
+++ b/build_info/repos
@@ -20,7 +20,7 @@ https://github.com/h5p/h5p-summary.git
 https://github.com/h5p/h5p-transition.git
 https://github.com/h5p/h5p-single-choice-set.git
 https://github.com/h5p/h5p-soundjs.git
-https://github.com/NDLANO/h5p-editor-ndla-virtual-tour.git
+https://github.com/NDLANO/h5p-editor-escape-room.git
 https://github.com/NDLANO/h5p-ndla-font-icons.git
 https://github.com/NDLANO/h5p-ndla-virtual-tour.git
 https://github.com/NDLANO/h5p-video.git

--- a/library.json
+++ b/library.json
@@ -39,7 +39,7 @@
   ],
   "editorDependencies": [
     {
-      "machineName": "H5PEditor.NDLAThreeImage",
+      "machineName": "H5PEditor.EscapeRoom",
       "majorVersion": 0,
       "minorVersion": 5
     },

--- a/semantics.json
+++ b/semantics.json
@@ -2,7 +2,7 @@
   {
     "name": "threeImage",
     "type": "group",
-    "widget": "NDLAthreeImage",
+    "widget": "EscapeRoom",
     "label": "Three Image Editor",
     "importance": "high",
     "fields": [


### PR DESCRIPTION
Renames `H5PEditor.NDLAThreeImage` dependency repo to `H5PEditor.EscapeRoom`.
Need to change updated major/minor version if needed as well.