### PR TITLE
Add focus trap workaround for brightcove in fullscreen

### DIFF
--- a/scripts/utils/focus-trap.js
+++ b/scripts/utils/focus-trap.js
@@ -48,7 +48,10 @@ export default class FocusTrap {
 
     callback(() => {
       this.observer = this.observer || new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting) {
+        // Custom NDLA workaround for Brightcove videos in fullscreen
+        const isBrightcove = !!entries[0].target.querySelector('.h5p-brightcove');
+
+        if (entries[0].isIntersecting || isBrightcove && H5P.isFullscreen) {
           this.observer.unobserve(this.params.trapElement);
 
           this.handleVisible();


### PR DESCRIPTION
Add custom workaround for Brightcove videos which for some reason are causing the IntersectionObserver to not work properly in full screen mode (works with other videos though).