### PR TITLE
Change media dialog

### DIFF
--- a/scripts/components/Dialog/Dialog.scss
+++ b/scripts/components/Dialog/Dialog.scss
@@ -37,9 +37,8 @@
   transform: translate(-50%, -50%);
   left: 50%;
   top: 50%;
-  width: 80%;
+  width: 50%;
   max-height: 90%;
-  max-width: 40em;
   background: white;
   z-index: 1;
   padding: 2em;

--- a/scripts/components/Dialog/InteractionContent.js
+++ b/scripts/components/Dialog/InteractionContent.js
@@ -115,6 +115,7 @@ export default class InteractionContent extends React.Component {
           interaction.action.params.sources[0].mime === 'video/ogg'
         )
       );
+      interaction.action.params.visuals.disableFullscreen = true;
     }
 
     this.instance = H5P.newRunnable(

--- a/scripts/components/Dialog/InteractionContent.scss
+++ b/scripts/components/Dialog/InteractionContent.scss
@@ -12,34 +12,34 @@
   object-fit: contain;
 }
 
-.h5p-text-content > .h5p-video {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  padding: 0;
-
-  > video::-webkit-media-controls-fullscreen-button {
-    display: none;
-  }
-
-  &.h5p-youtube {
-    background-color: #000;
-    &> div {
-      left: 50%;
-      position: absolute;
-      top: 50%;
-      transform: translate(-50%, -50%);
-    }
-  }
-}
-
 .h5p-text-dialog.h5p-video {
-  height: 80%;
+  height: auto;
+  padding: 0;
+  width: 90%;
 
   .h5p-text-content {
-    height: 100%;
+    height: auto;
     overflow: hidden;
+    padding: 0;
+
+    & > .h5p-video {
+      width: 100%;
+      height: 100%;
+      padding: 0;
+
+      > video::-webkit-media-controls-fullscreen-button {
+        display: none;
+      }
+
+      &.h5p-youtube {
+        background-color: #000;
+        &> div {
+          left: 50%;
+          position: absolute;
+          top: 50%;
+          transform: translate(-50%, -50%);
+        }
+      }
+    }
   }
 }

--- a/scripts/components/Dialog/InteractionContent.scss
+++ b/scripts/components/Dialog/InteractionContent.scss
@@ -33,12 +33,6 @@
 
       &.h5p-youtube {
         background-color: #000;
-        &> div {
-          left: 50%;
-          position: absolute;
-          top: 50%;
-          transform: translate(-50%, -50%);
-        }
       }
     }
   }

--- a/scripts/components/Dialog/InteractionContent.scss
+++ b/scripts/components/Dialog/InteractionContent.scss
@@ -20,6 +20,10 @@
   height: 100%;
   padding: 0;
 
+  > video::-webkit-media-controls-fullscreen-button {
+    display: none;
+  }
+
   &.h5p-youtube {
     background-color: #000;
     &> div {


### PR DESCRIPTION
When merged in, will
- Remove the fullscreen button of HTML videos
- Use 90% of parent width for videos

Note: This dialog still suffers from the original approach to not use H5P videos but to add media with custom players. The code/css feels a little odd and overly nested. Not touching that now though.