### PR TITLE
Add tab order setup

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -240,6 +240,21 @@
       "description": "These options will let you control how the world behaves.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/bg.json
+++ b/language/bg.json
@@ -240,6 +240,21 @@
       "description": "Тези настройки ще ви позволят за контролирате поведението на задачата.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/ca.json
+++ b/language/ca.json
@@ -240,6 +240,21 @@
       "description": "Aquestes opcions us permeten controlar com es comporta el món.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/cs.json
+++ b/language/cs.json
@@ -240,6 +240,21 @@
       "description": "Tyto možnosti vám umožní řídit, jak se budou scény chovat.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Typ zvuku",
           "description": "Rozhodněte, jaký typ zvuku bude tato scéna používat, buď použijte zvukovou stopu, nebo vyberte existující seznam zvukových stop.",
           "options": [

--- a/language/de.json
+++ b/language/de.json
@@ -240,6 +240,21 @@
       "description": "Diese Optionen legen fest, wie die Tour im Detail funktioniert.",
       "fields": [
         {
+          "label": "Tab-Reihenfolge",
+          "description": "Lege fest, wie die Tab-Reihenfolge bestimmt werden soll.",
+          "options": [
+            {
+              "label": "Keine spezifische Reihenfolge"
+            },
+            {
+              "label": "Automatisch in Lesereihenfolge"
+            },
+            {
+              "label": "Manuell durch eigene Reihenfolge"
+            }
+          ]
+        },
+        {
           "label": "Tontyp",
           "description": "Entscheide, welchen Audiotyp diese Szene verwenden soll. Verwende entweder eine Tonspur oder wähle eine vorhandene Wiedergabeliste.",
           "options": [

--- a/language/el.json
+++ b/language/el.json
@@ -240,6 +240,21 @@
       "description": "Ρυθμίσεις που ελέγχουν τη συμπεριφορά του αντικειμένου.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -240,6 +240,21 @@
       "description": "Estas opciones le permitirán controlar como se comporta el mundo.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Tipo de audio",
           "description": "Decidir qué tipo de audio usará esta escena, ya sea una pista de audio o elegir una lista de reproducción de audio existente.",
           "options": [

--- a/language/es.json
+++ b/language/es.json
@@ -240,6 +240,21 @@
       "description": "Estas opciones le permitirán controlar como se comporta el mundo.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Tipo de audio",
           "description": "Decidir qué tipo de audio usará esta escena, ya sea una pista de audio o elegir una lista de reproducción de audio existente.",
           "options": [

--- a/language/et.json
+++ b/language/et.json
@@ -240,6 +240,21 @@
       "description": "Need valikud määravad, kuidas maailm käitub.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/eu.json
+++ b/language/eu.json
@@ -240,6 +240,21 @@
       "description": "Aukera hauek munduaren portaera kontrolatzen utziko dizute.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/fi.json
+++ b/language/fi.json
@@ -240,6 +240,21 @@
       "description": "Nämä asetukset määrittelevät kuinka tehtävä käyttäytyy.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/fr.json
+++ b/language/fr.json
@@ -240,6 +240,21 @@
       "description": "Ces options vous permettront de contrôler comment le monde doit se comporter.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Type d'audio",
           "description": "Décidez du type audio que cette scène utilisera, soit utiliser une piste audio ou choisir une liste de lecture audio existante.",
           "options": [

--- a/language/gl.json
+++ b/language/gl.json
@@ -240,6 +240,21 @@
       "description": "Estas opcións permítenche controlar o comportamento da tarefa.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Tipo de son",
           "description": "Decide que tipo de son usará esta escena, ben utiliza unha pista de son ou escolle unha lista de reprodución existente.",
           "options": [

--- a/language/it.json
+++ b/language/it.json
@@ -240,6 +240,21 @@
       "description": "Queste opzioni ti permettono di controllare il movimento del globo",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/ko.json
+++ b/language/ko.json
@@ -240,6 +240,21 @@
       "description": "These options will let you control how the world behaves.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "콘텐츠 유형",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/lt.json
+++ b/language/lt.json
@@ -240,6 +240,21 @@
       "description": "These options will let you control how the world behaves.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/nb.json
+++ b/language/nb.json
@@ -240,6 +240,21 @@
       "description": "Disse valga lar deg bestemme hvordan den virtuelle turen skal fungere.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Lydtype",
           "description": "Bestem hvilken lydtype scenen skal ha, enten et lydspor eller ei eksisterende spilleliste.",
           "options": [

--- a/language/nl.json
+++ b/language/nl.json
@@ -240,6 +240,21 @@
       "description": "Met deze opties kun je bepalen hoe de interactie zich gedraagt.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/nn.json
+++ b/language/nn.json
@@ -240,6 +240,21 @@
       "description": "Desse vala lèt deg styre korleis verda oppfører seg.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Lydtype",
           "description": "Bestem kva lydtype scenen skal bruke, anten eit lydspor eller ei eksisterande spilleliste.",
           "options": [

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -240,6 +240,21 @@
       "description": "Estas opções deixarão você controlar como o mundo se comporta.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/sl.json
+++ b/language/sl.json
@@ -240,6 +240,21 @@
       "description": "Nastavitve omogočajo nadzor nad interakcijo aktivnosti za udeležence.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Decide what audio type this scene will use, either use an audio track or choose an existing audio playlist.",
           "options": [

--- a/language/sv.json
+++ b/language/sv.json
@@ -240,6 +240,21 @@
       "description": "Dessa inställningar avgör hur världen beter sig.",
       "fields": [
         {
+          "label": "Tab order",
+          "description": "Set how the tab order of interactions should be determined",
+          "options": [
+            {
+              "label": "No specific order"
+            },
+            {
+              "label": "Automatically by reading order"
+            },
+            {
+              "label": "Manually by custom order"
+            }
+          ]
+        },
+        {
           "label": "Audio type",
           "description": "Ställ in vilken ljudtyp denna scen ska använda, använd antingen ett ljudspår eller välj en befintlig spellista.",
           "options": [

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -126,6 +126,7 @@ export default class Wrapper extends H5P.EventDispatcher {
           fullScreenSupported={this.isFullScreenSupported}
           fullscreenButtonAriaLabel={this.fullscreenButtonAriaLabel}
           onFullscreenClicked={this.toggleFullscreen.bind(this)}
+
         />
       </H5PContext.Provider>
     );
@@ -142,6 +143,19 @@ export default class Wrapper extends H5P.EventDispatcher {
   setCurrentSceneId(sceneId) {
     this.currentSceneId = sceneId;
     this.trigger('changedScene', sceneId);
+    this.render();
+  }
+
+  /**
+   * Set tab order mode. Usually only used by editor.
+   * @param {string} tabOrderMode Tab order mode.
+   */
+  setTabOrderMode(tabOrderMode) {
+    if (!tabOrderMode) {
+      return;
+    }
+
+    this.behavior.tabOrderMode = tabOrderMode;
     this.render();
   }
 

--- a/scripts/components/Main.js
+++ b/scripts/components/Main.js
@@ -879,6 +879,7 @@ export default class Main extends React.Component {
 
     return (
       <div
+        className={ 'h5p-escape-room-document' }
         role="document"
         aria-label={ this.context.l10n.title }
         id={ this.documentID }
@@ -989,6 +990,7 @@ export default class Main extends React.Component {
                 on360AffordanceDone={ () => {
                   this.show360Affordance = false;
                 } }
+                tabOrderMode={ this.context.behavior.tabOrderMode }
               />
             );
           })

--- a/scripts/components/Main.scss
+++ b/scripts/components/Main.scss
@@ -26,13 +26,19 @@
   outline: none;
 }
 
-.h5p-editor-escape-room-wrapper .h5p-editing-overlay {
-  z-index: 4;
+.h5p-escape-room-document {
+  position: relative;
 }
 
-/* Hide overflow of static image in scene container when zooming in */
-.h5p-editor-escape-room-wrapper .h5p-escape-room.scene-container {
-  overflow: hidden;
+.h5p-editor-escape-room-wrapper {
+  .h5p-editing-overlay {
+    z-index: 4;
+  }
+
+  /* Hide overflow of static image in scene container when zooming in */
+  .h5p-escape-room.scene-container {
+    overflow: hidden;
+  }
 }
 
 .do-not-display {

--- a/scripts/components/Scene/Scene.js
+++ b/scripts/components/Scene/Scene.js
@@ -47,6 +47,14 @@ export default class Scene extends React.Component {
   }
 
   /**
+   * Handle scene was updated.
+   * @param {number} sceneId SceneId.
+   */
+  handleSceneUpdated(sceneId) {
+    this.context.trigger('sceneUpdated', { sceneId });
+  }
+
+  /**
    * Get interaction title.
    * @param {object} action Action.
    * @returns {string} Title.
@@ -96,6 +104,8 @@ export default class Scene extends React.Component {
           maxZoomedIn={ this.props.maxZoomedIn }
           maxZoomedOut={ this.props.maxZoomedOut }
           tabIndexOffset={ 2 } // Fullscreen button has tabIndex 1, scene has no tanIndex
+          tabOrderMode={ this.props.tabOrderMode }
+          onUpdated={ this.handleSceneUpdated.bind(this) }
         />
       );
     }
@@ -136,6 +146,8 @@ export default class Scene extends React.Component {
         show360Affordance={ this.props.show360Affordance }
         on360AffordanceDone={ this.props.on360AffordanceDone }
         tabIndexOffset={ 3 } // Fullscreen button has tabIndex 1, scene has tabIndex 2
+        tabOrderMode={ this.props.tabOrderMode }
+        onUpdated= { this.handleSceneUpdated.bind(this) }
       />
     );
   }
@@ -183,4 +195,5 @@ Scene.propTypes = {
   maxZoomedOut: PropTypes.bool.isRequired,
   sceneDescriptionARIA: PropTypes.string,
   read: PropTypes.func.isRequired,
+  tabOrderMode: PropTypes.string
 };

--- a/scripts/components/Scene/SceneTypes/StaticScene.js
+++ b/scripts/components/Scene/SceneTypes/StaticScene.js
@@ -136,6 +136,8 @@ export default class StaticScene extends React.Component {
 
       this.prevZoomScale = this.props.zoomScale;
     }
+
+    this.props.onUpdated?.(this.props.sceneParams.sceneId);
   }
 
   /**
@@ -911,8 +913,9 @@ export default class StaticScene extends React.Component {
       return null;
     }
 
-    const interactions = (this.props.sceneParams.interactions || [])
-      .sort((a, b, index) => {
+    let interactions = (this.props.sceneParams.interactions || []);
+    if (this.props.tabOrderMode === 'readingOrder') {
+      interactions.sort((a, b, index) => {
         const positionA = this.getPositions(a.interactionpos);
         const positionB = this.getPositions(b.interactionpos);
 
@@ -921,8 +924,8 @@ export default class StaticScene extends React.Component {
         }
 
         return parseFloat(positionA.y) - parseFloat(positionB.y);
-      })
-    ;
+      });
+    }
 
     const hasPreviousScene = this.props.sceneHistory.length > 0;
     const isShowingBackButton = this.props.sceneParams.showBackButton
@@ -1145,4 +1148,6 @@ StaticScene.propTypes = {
   nextFocus: PropTypes.string,
   wasConvertedFromVirtualTour: PropTypes.bool.isRequired,
   tabIndexOffset: PropTypes.number,
+  tabOrderMode: PropTypes.string,
+  onUpdated: PropTypes.func,
 };

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -412,8 +412,9 @@ export default class ThreeSixtyScene extends React.Component {
    * @param {object[]} interactions Interactions.
    */
   addInteractionHotspots(threeSixty, interactions) {
-    const list = (interactions ?? [])
-      .sort((a, b) => {
+    let list = (interactions ?? []);
+    if (this.props.tabOrderMode === 'readingOrder') {
+      list.sort((a, b) => {
         const positionA = ThreeSixtyScene.getPositionFromString(a.interactionpos);
         const positionB = ThreeSixtyScene.getPositionFromString(b.interactionpos);
 
@@ -422,8 +423,10 @@ export default class ThreeSixtyScene extends React.Component {
           return positionA.yaw - positionB.yaw;
         }
         return positionB.pitch - positionA.pitch;
-      })
-      .map((interaction, index) => this.createInteraction(interaction, index));
+      });
+    }
+
+    list = list.map((interaction, index) => this.createInteraction(interaction, index));
 
     const components2d = list.filter((interaction) => !interaction.is3d).map((interaction) => interaction.component);
     const components3d = list.filter((interaction) => interaction.is3d).map((interaction) => interaction.component);
@@ -667,6 +670,8 @@ export default class ThreeSixtyScene extends React.Component {
       this.setState({
         isUpdated: true
       });
+
+      this.props.onUpdated?.(this.props.sceneParams.sceneId);
     }
 
     // Only load scene if image exists
@@ -848,4 +853,6 @@ ThreeSixtyScene.propTypes = {
   on360AffordanceDone: PropTypes.func,
   zoomPercentage: PropTypes.number.isRequired,
   tabIndexOffset: PropTypes.number,
+  tabOrderMode: PropTypes.string,
+  onUpdated: PropTypes.func,
 };

--- a/scripts/utils/sanitization.js
+++ b/scripts/utils/sanitization.js
@@ -84,7 +84,8 @@ export const sanitizeContentTypeParameters = (params = {}) => {
       label: {
         labelPosition: 'right',
         showLabel: true
-      }
+      },
+      tabOrderMode: 'none'
     },
     l10n: {
       title: 'Virtual Tour',

--- a/semantics.json
+++ b/semantics.json
@@ -504,6 +504,27 @@
     "description": "These options will let you control how the world behaves.",
     "fields": [
       {
+        "name": "tabOrderMode",
+        "type": "select",
+        "label": "Tab order",
+        "description": "Set how the tab order of interactions should be determined",
+        "options": [
+          {
+            "label": "No specific order",
+            "value": "none"
+          },
+          {
+            "label": "Automatically by reading order",
+            "value": "readingOrder"
+          },
+          {
+            "label": "Manually by custom order",
+            "value": "custom"
+          }
+        ],
+        "default": "none"
+      },
+      {
         "name": "audioType",
         "type": "select",
         "label": "Audio type",


### PR DESCRIPTION
When merged in, will allow to customize the tab order of interactions. Requires related changes to the editor.